### PR TITLE
Update around Sequence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ criterion = "0.5.1"
 default = ["audio"]
 audio = ["bevy/bevy_audio", "bevy/bevy_asset"]
 
-
 [workspace.lints.clippy]
 type_complexity = "allow"
 doc_markdown = "warn"

--- a/benches/cmp_countup.rs
+++ b/benches/cmp_countup.rs
@@ -6,7 +6,6 @@ use bevy::prelude::{EventReader, EventWriter, Local, ResMut, Resource, Update, W
 use criterion::{Criterion, criterion_group, criterion_main};
 
 use bevy_flurx::{FlurxPlugin, sequence};
-
 use bevy_flurx::extension::ScheduleReactor;
 use bevy_flurx::prelude::{once, wait};
 

--- a/examples/simple/sequence.rs
+++ b/examples/simple/sequence.rs
@@ -1,4 +1,4 @@
-//! [`sequence!`] create actions that execute the passed actions in sequence.
+//! [`sequence_with_output!`] create actions that execute the passed actions in sequence.
 //! 
 //! It has advantage that if the previous action finishes, 
 //! the next will start within in that frame. 
@@ -6,7 +6,7 @@
 use bevy::core::FrameCount;
 use bevy::prelude::*;
 use bevy_flurx::prelude::*;
-use bevy_flurx::sequence;
+use bevy_flurx::sequence_with_output;
 
 fn main() {
     App::new()
@@ -40,7 +40,7 @@ fn setup_non_sequence(world: &mut World) {
 
 fn setup_sequence(world: &mut World) {
     world.schedule_reactor(|task| async move {
-        task.will(Update, sequence! {
+        task.will(Update, sequence_with_output! {
             once::run(|frame: Res<FrameCount>|{
                 println!("[sequence once1] frame: {}", frame.0);
             }),

--- a/src/action.rs
+++ b/src/action.rs
@@ -15,7 +15,8 @@ pub mod once;
 pub mod wait;
 pub mod repeat;
 pub mod delay;
-mod sequence;
+pub mod sequence;
+mod sequence_with_output;
 
 
 #[doc(hidden)]

--- a/src/action/sequence_with_output.rs
+++ b/src/action/sequence_with_output.rs
@@ -1,0 +1,154 @@
+/// Create actions that execute the passed actions in sequence.
+///
+/// It has advantage that if the previous action finishes, 
+/// the next will start within in that frame. 
+///
+/// For example, the code below defines three actions, 
+/// all of which are executed during one frame.
+///
+/// ```no_run
+/// use bevy::app::{App, Update};
+/// use bevy::prelude::World;
+/// use bevy_flurx::prelude::*;
+/// use bevy_flurx::sequence_with_output;
+///
+/// let mut app = App::new();
+/// app.world.schedule_reactor(|task| async move{
+///     let (o1, o2, ..) = task.will(Update, sequence_with_output!{
+///         once::run(||{
+///             1 + 1
+///         }),
+///         once::run(||{
+///             "hello"
+///         }),
+///         once::event::app_exit()
+///     }).await;
+///     assert_eq!(o1, 2);
+///     assert_eq!(o2, "hello");
+/// });
+/// app.update();
+/// ```
+///
+#[macro_export]
+macro_rules! sequence_with_output {
+    ($action: expr $(,)?) => {$action};
+    ($action1: expr, $action2: expr $(,$action: expr)*$(,)?)  => {
+        {
+            let a = $crate::private::SequenceWithOutputRunner::new($crate::action::to_tuple($action1), $action2);
+            $(
+            let a = $crate::private::SequenceWithOutputRunner::new(a, $action);
+            )*
+            a
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::app::{AppExit, Startup, Update};
+    use bevy::ecs::system::RunSystemOnce;
+    use bevy::prelude::{EventWriter, ResMut, Resource, World};
+    use bevy_test_helper::event::TestEvent1;
+
+    use crate::action::{once, wait};
+    use crate::extension::ScheduleReactor;
+    use crate::tests::test_app;
+
+    #[test]
+    fn one() {
+        let mut app = test_app();
+        app
+            .add_systems(Startup, |world: &mut World| {
+                world.schedule_reactor(|task| async move {
+                    task.will(Update, sequence_with_output! {
+                        once::non_send::insert(AppExit)
+                    }).await;
+                });
+            });
+
+        app.update();
+        assert!(app.world.get_non_send_resource::<AppExit>().is_some());
+    }
+
+    #[test]
+    fn two() {
+        let mut app = test_app();
+
+        app
+            .add_systems(Startup, |world: &mut World| {
+                world.schedule_reactor(|task| async move {
+                    task.will(Update, sequence_with_output! {
+                        wait::event::read::<TestEvent1>(),
+                        once::non_send::insert(AppExit)
+                    }).await;
+                });
+            });
+
+        app.world.run_system_once(|mut w: EventWriter<TestEvent1>| w.send(TestEvent1));
+        app.update();
+        assert!(app.world.get_non_send_resource::<AppExit>().is_some());
+    }
+
+    #[test]
+    fn three() {
+        let mut app = test_app();
+        #[derive(Resource, Default)]
+        struct Count1(usize);
+
+        #[derive(Resource, Default)]
+        struct Count2(usize);
+
+        app
+            .init_resource::<Count1>()
+            .init_resource::<Count2>()
+            .add_systems(Startup, |world: &mut World| {
+                world.schedule_reactor(|task| async move {
+                    task.will(Update, sequence_with_output! {
+                        once::run(|mut c:  ResMut<Count1>|{
+                            c.0 += 1;
+                        }),
+                        wait::until(|mut c:  ResMut<Count2>|{
+                            c.0 += 1;
+                            c.0 == 2
+                        }),
+                        once::non_send::insert(AppExit)
+                    }).await;
+                });
+            });
+        app.update();
+        assert_eq!(app.world.resource::<Count1>().0, 1);
+        assert_eq!(app.world.resource::<Count2>().0, 1);
+        assert!(app.world.get_non_send_resource::<AppExit>().is_none());
+
+        app.update();
+        assert_eq!(app.world.resource::<Count1>().0, 1);
+        assert_eq!(app.world.resource::<Count2>().0, 2);
+        assert!(app.world.get_non_send_resource::<AppExit>().is_some());
+    }
+
+    #[test]
+    fn output() {
+        let mut app = test_app();
+        app
+            .add_systems(Startup, |world: &mut World| {
+                world.schedule_reactor(|task| async move {
+                    let o = task.will(Update, sequence_with_output! {
+                        once::run(||{
+                            1 + 1
+                        }),
+                        once::run(||{
+                            "hello"
+                        }),
+                        once::run(||{
+                            "world"
+                        }),
+                    }).await;
+                    assert_eq!(o, (2, "hello", "world"));
+                });
+            });
+        app.update();
+    }
+}
+
+
+

--- a/src/action/wait/input.rs
+++ b/src/action/wait/input.rs
@@ -141,7 +141,7 @@ mod tests {
 
     use crate::action::{once, wait};
     use crate::extension::ScheduleReactor;
-    use crate::sequence;
+    use crate::sequence_with_output;
     use crate::tests::test_app;
 
     #[test]
@@ -149,7 +149,7 @@ mod tests {
         let mut app = test_app();
         app.add_systems(Startup, |world: &mut World| {
             world.schedule_reactor(|task| async move {
-                task.will(First, sequence! {
+                task.will(First, sequence_with_output! {
                     wait::input::just_pressed(KeyCode::KeyA),
                     wait::input::pressed(KeyA),
                     once::run(|world: &mut World|{
@@ -172,13 +172,13 @@ mod tests {
         let mut app = test_app();
         app.add_systems(Startup, |world: &mut World| {
             world.schedule_reactor(|task| async move {
-                task.will(First, sequence! {
+                task.will(First, sequence_with_output! {
                     wait::input::any_pressed([KeyA, KeyB]),
                     once::run(|world: &mut World|{
                         world.set_bool(true);
                     })
                 }).await;
-                task.will(First, sequence! {
+                task.will(First, sequence_with_output! {
                     wait::input::any_pressed([KeyA, KeyD]),
                     once::run(|world: &mut World|{
                         world.set_bool(true);
@@ -209,7 +209,7 @@ mod tests {
         let mut app = test_app();
         app.add_systems(Startup, |world: &mut World| {
             world.schedule_reactor(|task| async move {
-                task.will(First, sequence! {
+                task.will(First, sequence_with_output! {
                     wait::input::all_pressed([KeyA, KeyB]),
                     once::run(|world: &mut World|{
                         world.set_bool(true);
@@ -235,7 +235,7 @@ mod tests {
         let mut app = test_app();
         app.add_systems(Startup, |world: &mut World| {
             world.schedule_reactor(|task| async move {
-                task.will(First, sequence! {
+                task.will(First, sequence_with_output! {
                     wait::input::just_released(KeyA),
                     once::run(|world: &mut World|{
                         world.set_bool(true);
@@ -261,7 +261,7 @@ mod tests {
         let mut app = test_app();
         app.add_systems(Startup, |world: &mut World| {
             world.schedule_reactor(|task| async move {
-                task.will(First, sequence! {
+                task.will(First, sequence_with_output! {
                     wait::input::any_just_released([KeyCode::KeyA, KeyCode::KeyB]),
                     once::run(|world: &mut World|{
                         world.set_bool(true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,9 @@ pub mod prelude {
 
 #[doc(hidden)]
 pub mod private {
-    pub use crate::runner::sequence::SequenceRunner;
+    pub use crate::runner::{
+        sequence_with_output::SequenceWithOutputRunner
+    };
 }
 
 mod world_ptr;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -10,8 +10,10 @@ pub(crate) mod runners;
 pub(crate) mod multi_times;
 pub(crate) mod once;
 pub(crate) mod sequence;
+pub(crate) mod sequence_with_output;
 pub(crate) mod both;
 pub(crate) mod either;
+
 
 /// Represents the output of the task.
 /// See details [`TaskRunner`].
@@ -53,14 +55,14 @@ impl<O> TaskOutput<O> {
     }
 }
 
-/// 
+///
 pub trait TaskRunner {
     /// Run the system. 
     ///
     /// The structure that implements [`TaskRunner`] is given [`TaskOutput`],
     /// if the system termination condition is met, return `true` and
     /// pass the system output to [`TaskOutput`].
-    /// 
+    ///
     fn run(&mut self, world: &mut World) -> bool;
 }
 
@@ -115,6 +117,7 @@ impl<O, R: RunWithTaskOutput<O>> TaskRunner for (TaskOutput<O>, R) {
         self.1.run_with_task_output(&mut self.0, world)
     }
 }
+
 
 pub(crate) mod macros {
     macro_rules! output_combine {

--- a/src/runner/sequence_with_output.rs
+++ b/src/runner/sequence_with_output.rs
@@ -1,0 +1,67 @@
+use std::marker::PhantomData;
+
+use crate::action::TaskAction;
+use crate::runner::{TaskRunner, RunWithTaskOutput, TaskOutput};
+use crate::runner::macros::{impl_tuple_runner, output_combine};
+
+pub struct SequenceWithOutputRunner<I1, I2, O1, O2, M1, M2> {
+    r1: Box<dyn TaskRunner>,
+    r2: Box<dyn TaskRunner>,
+    o1: TaskOutput<O1>,
+    o2: TaskOutput<O2>,
+    _m: PhantomData<(I1, I2, M1, M2)>,
+}
+
+impl<I1, I2, O1, O2, M1, M2> SequenceWithOutputRunner<I1, I2, O1, O2, M1, M2> {
+    #[inline]
+    pub fn new(
+        a1: impl TaskAction<M1, In=I1, Out=O1> + 'static,
+        a2: impl TaskAction<M2, In=I2, Out=O2> + 'static,
+    ) -> SequenceWithOutputRunner<I1, I2, O1, O2, M1, M2>
+        where
+            M1: 'static,
+            M2: 'static
+    {
+        let o1 = TaskOutput::default();
+        let o2 = TaskOutput::default();
+        let r1 = a1.to_runner(o1.clone());
+        let r2 = a2.to_runner(o2.clone());
+        Self {
+            r1: Box::new(r1),
+            r2: Box::new(r2),
+            o1,
+            o2,
+            _m: PhantomData,
+        }
+    }
+}
+
+macro_rules! impl_sequence_runner {
+    ($($lhs_out: ident $(,)?)*) => {
+        impl<I1, I2, $($lhs_out,)* O2, M1, M2> TaskAction for SequenceWithOutputRunner<I1, I2, ($($lhs_out,)*), O2, M1, M2> {
+            type In = (I1, I2);
+            type Out = ($($lhs_out,)* O2);
+
+            #[inline(always)]
+            fn to_runner(self, output: TaskOutput<Self::Out>) -> impl TaskRunner {
+                (output, self)
+            }
+        }
+
+        #[allow(non_snake_case)]
+        impl<I1, I2, $($lhs_out,)* O2, M1, M2> RunWithTaskOutput<($($lhs_out,)* O2)> for SequenceWithOutputRunner<I1, I2, ($($lhs_out,)*), O2, M1, M2> {
+            fn run_with_task_output(&mut self, output: &mut TaskOutput<($($lhs_out,)* O2)>, world: &mut bevy::prelude::World) -> bool {
+                if self.o1.is_none() {
+                    self.r1.run(world);
+                }
+                if self.o1.is_some() && self.o2.is_none() {
+                    self.r2.run(world);
+                }
+                output_combine!(&self.o1, &self.o2, output, $($lhs_out),*)
+            }
+        }
+    }
+}
+
+impl_tuple_runner!(impl_sequence_runner);
+


### PR DESCRIPTION
Added `Then` trait, `sequence!` and `sequence_with_output!`.

`Then` can be used as follows.
```rust
task.will(Update, {
   once::run(||{})
       .then(once::run(||{}))
       .then(once::run(||{}))
})
``` 

`sequence!` macro is the same as `Then` in behavior itself.
The following is a replacement for the above code.
```rust
task.will(Update, sequence!{
      once::run(||{}),
      once::run(||{}),
      once::run(||{}),
})
```

`sequence_with_output!` returns the output of all actions as return value of the future.
```rust
let (o1, o2, o3) = task.will(Update, sequence!{
      once::run(||{1}),
      once::run(||{2}),
      once::run(||{3}),
}).await;
assert_eq!(o1, 1);
assert_eq!(o2, 2);
assert_eq!(o3, 3);
```
