### PR TITLE
UPDATE: improved performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ harness = false
 
 [dependencies]
 bevy = { version = "0.13.2", default-features = false }
-flurx = { version = "0.1.3", features = ["sync"] }
+flurx = { git = "https://github.com/not-elm/flurx", features = ["sync"], branch = "feature/bevy" }
 futures-lite = "2.2.0"
 futures-polling = "0.1.1"
 

--- a/benches/cmp_countup.rs
+++ b/benches/cmp_countup.rs
@@ -74,23 +74,11 @@ fn with_flurx(count: usize, c: &mut Criterion) {
     });
 }
 
-fn cmp_count_100(c: &mut Criterion){
-    const COUNT: usize = 100;
-    without_flurx(COUNT, c);
-    with_flurx(COUNT, c);
-}
-
-fn cmp_count_500(c: &mut Criterion){
-    const COUNT: usize = 500;
-    without_flurx(COUNT, c);
-    with_flurx(COUNT, c);
-}
-
-fn cmp_count_1000(c: &mut Criterion){
+fn cmp_count_1000(c: &mut Criterion) {
     const COUNT: usize = 1000;
     without_flurx(COUNT, c);
     with_flurx(COUNT, c);
 }
 
-criterion_group!(cmp_countup, cmp_count_100, cmp_count_500, cmp_count_1000);
+criterion_group!(cmp_countup, cmp_count_1000);
 criterion_main!(cmp_countup);


### PR DESCRIPTION
Related to #5 

- Optimized `flurx` algorithm for `bevy_flurx`.
- Fixed timing of `run_reactors` execution to be after `Last

<details>
<summary>previous</summary>

cmp_countup.rs
```
without_flurx count: 1000
                        time:   [18.238 ms 18.975 ms 19.734 ms]

with_flurx count: 1000  time:   [27.181 ms 28.189 ms 29.252 ms]
```

cmp_repeat_countup.rs
```
without_flurx repeat: 10 count: 1000
                        time:   [201.61 ms 209.61 ms 218.02 ms]

with_flurx repeat: 10 count: 1000
                        time:   [307.13 ms 319.15 ms 331.66 ms]

without_flurx repeat: 1000 count: 1
                        time:   [27.743 ms 28.451 ms 29.218 ms]

with_flurx repeat: 1000 count: 1
                        time:   [32.174 ms 33.753 ms 35.463 ms]
```

</details>

<details>
<summary>current</summary>

cmp_countup.rs
```
without_flurx count: 1000
                        time:   [20.795 ms 21.947 ms 23.270 ms]

with_flurx count: 1000  time:   [19.510 ms 20.597 ms 21.823 ms]
```

cmp_repeat_countup.rs
```
without_flurx repeat: 10 count: 1000
                        time:   [194.49 ms 199.80 ms 205.49 ms]

with_flurx repeat: 10 count: 1000
                        time:   [204.30 ms 210.28 ms 216.38 ms]

without_flurx repeat: 1000 count: 1
                        time:   [27.617 ms 28.480 ms 29.454 ms]

with_flurx repeat: 1000 count: 1
                        time:   [23.361 ms 24.171 ms 25.115 ms]
```

</details>