### PR TITLE
add map action trait

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -33,6 +33,7 @@
 //! - [`tuple`] 
 //! - [`omit`]
 
+pub use map::Map;
 pub use omit::{Omit, OmitInput, OmitOutput};
 pub use remake::Remake;
 pub use through::through;
@@ -53,7 +54,7 @@ pub mod sequence;
 mod repeat;
 mod tuple;
 mod omit;
-pub mod map;
+mod map;
 mod remake;
 
 /// Represents the system passed to [`ReactiveTask`](crate::task::ReactiveTask).

--- a/src/action/map.rs
+++ b/src/action/map.rs
@@ -3,7 +3,27 @@ use bevy::prelude::World;
 use crate::action::remake::Remake;
 use crate::runner::{BoxedRunner, CancellationToken, Output, Runner};
 
+/// Maps an `Action<I1, O1>` to `Action<I1, O2>` or `ActionSeed<I1, O1>` to `ActionSeed<I1, O2>` by
+/// applying function.
 pub trait Map<I1, O1, O2, ActionOrSeed> {
+    /// Maps an `Action<I1, O1>` to `Action<I1, O2>` or `ActionSeed<I1, O1>` to `ActionSeed<I1, O2>` by
+    /// applying function.
+    /// 
+    /// # Examples
+    /// 
+    /// ```no_run
+    /// use bevy::prelude::*;
+    /// use bevy_flurx::prelude::*;
+    /// 
+    /// Reactor::schedule(|task| async move{
+    ///     task.will(Update, once::run(|| 3)
+    ///         .map(|num| num + 5)
+    ///         .pipe(once::run(|In(num): In<usize>|{
+    ///             assert_eq!(num, 8);
+    ///         }))
+    ///     ).await;
+    /// });
+    /// ```
     fn map(self, f: impl FnOnce(O1) -> O2 + 'static) -> ActionOrSeed;
 }
 

--- a/src/action/pipe.rs
+++ b/src/action/pipe.rs
@@ -39,12 +39,12 @@ pub trait Pipe<I1, O1, O2, A> {
     fn pipe(self, seed: ActionSeed<O1, O2>) -> A;
 }
 
-impl<I1, O1, O2, A, ActonOrSeed> Pipe<I1, O1, O2, A> for ActonOrSeed
+impl<I1, O1, O2, A, ActionOrSeed> Pipe<I1, O1, O2, A> for ActionOrSeed
     where
         I1: 'static,
         O1: 'static,
         O2: 'static,
-        ActonOrSeed: Remake<I1, O1, O2, A>
+        ActionOrSeed: Remake<I1, O1, O2, A>
 {
     #[inline(always)]
     fn pipe(self, seed: ActionSeed<O1, O2>) -> A {

--- a/src/action/remake.rs
+++ b/src/action/remake.rs
@@ -2,7 +2,9 @@ use crate::action::Action;
 use crate::prelude::{ActionSeed, Output, Runner};
 use crate::runner::{BoxedRunner, CancellationToken};
 
+/// Remake a new action base on itself [`Runner`] and [`Output`].
 pub trait Remake<I1, O1, O2, ActionOrSeed> {
+    /// Remake a new action base on itself [`Runner`] and [`Output`].
     fn remake<F, R>(self, f: F) -> ActionOrSeed
         where
             F: FnOnce(BoxedRunner, Output<O1>, CancellationToken, Output<O2>) -> R + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub mod prelude {
         action::switch::*,
         action::through::{through, Through},
         action::wait::Either,
-        action::map::Map,
+        action::Map,
         action::{Omit, OmitInput, OmitOutput},
         action::Remake,
         extension::ScheduleReactor,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12,14 +12,14 @@ use crate::world_ptr::WorldPtr;
 mod output;
 mod cancellation_token;
 
-///
+/// The structure that implements [`Runner`] is given [`Output`],
+/// if the system termination condition is met, return `true` and
+/// pass the system output to [`Output`].
 pub trait Runner {
-    /// Run the system. 
-    ///
-    /// The structure that implements [`Runner`] is given [`Output`],
-    /// if the system termination condition is met, return `true` and
-    /// pass the system output to [`Output`].
-    ///
+    /// Run the system.
+    /// 
+    /// If this runner finishes, it must return `true`.
+    /// If it returns `true`, an entity attached this runner will be removed.
     fn run(&mut self, world: &mut World) -> bool;
 }
 


### PR DESCRIPTION
Provides the mechanism to map the output of an action.

```rust
fn main() {
    use bevy::prelude::*;
    use bevy_flurx::prelude::*;

    Reactor::schedule(|task| async move {
        task.will(Update, once::run(|| 3)
            .map(|num| num + 5)
            .pipe(once::run(|In(num): In<usize>| {
                assert_eq!(num, 8);
            })),
        ).await;
    });
}
```