### PR TITLE
added wait::any and actions!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures-polling = "0.1.1"
 [dev-dependencies]
 bevy = { version = "0.13.2" }
 bevy_test_helper = { git = "https://github.com/not-elm/bevy_test_helper" }
-reqwest = "0.12.2"
+reqwest = "0.12.3"
 futures = "0.3.30"
 criterion = { version = "0.5.1", features = ["plotters", "html_reports"] }
 

--- a/src/action/delay.rs
+++ b/src/action/delay.rs
@@ -65,7 +65,6 @@ pub fn frames() -> ActionSeed<usize>  {
     })
 }
 
-
 #[cfg(test)]
 mod tests {
     use bevy::app::{AppExit, First, Startup, Update};

--- a/src/action/seed.rs
+++ b/src/action/seed.rs
@@ -60,12 +60,5 @@ impl<I, O, F> From<F> for ActionSeed<I, O>
     }
 }
 
-// impl<I, O> Clone for ActionSeed<I, O> {
-//     #[inline]
-//     fn clone(&self) -> Self {
-//         Self(self.0.clone(), PhantomData)
-//     }
-// }
-//
 
 

--- a/src/action/switch.rs
+++ b/src/action/switch.rs
@@ -17,7 +17,7 @@
 //! actions 
 //! 
 //! - [`once::switch::on`](crate::prelude::once::switch::on)
-//! - [`once::switch::on`](crate::prelude::once::switch::off)
+//! - [`once::switch::off`](crate::prelude::once::switch::off)
 //! - [`wait::switch::on`](crate::prelude::wait::switch::on)
 //! - [`wait::switch::off`](crate::prelude::wait::switch::off)
 

--- a/src/action/through.rs
+++ b/src/action/through.rs
@@ -57,7 +57,7 @@ pub fn through<V, I, O>(action: impl Into<Action<I, O>> + 'static) -> ActionSeed
 /// Provides a method version of [`through`].
 pub trait Through<I1, O1, O2, ActionOrSeed> {
     ///
-    /// This method is syntax sugar for [`through`].
+    /// This method is syntax sugar for `self.pipe(through(action))`.
     ///
     ///
     /// # Examples

--- a/src/action/wait.rs
+++ b/src/action/wait.rs
@@ -1,7 +1,7 @@
 //! [`wait`] creates a task that run the until the condition is met.
 //!
 //! actions
-//! 
+//!
 //! - [`wait::output`](crate::prelude::wait::output)
 //! - [`wait::both`](crate::prelude::wait::both)
 //! - [`wait::until`](crate::prelude::wait::until)
@@ -12,10 +12,12 @@
 //! - [`wait::switch`](crate::prelude::wait::switch)
 //! - [`wait::input`](crate::prelude::wait::input)
 //! - [`wait::audio`](crate::prelude::wait::audio) (require feature flag `audio`)
+//! - [`wait::any`]
 
 
 use bevy::prelude::{In, IntoSystem, System, World};
 
+pub use any::any;
 pub use both::both;
 pub use either::*;
 
@@ -33,6 +35,8 @@ pub mod all;
 pub mod audio;
 mod either;
 mod both;
+mod any;
+
 
 /// Run until it returns [`Option::Some`].
 /// The contents of Some will be return value of the task.

--- a/src/action/wait/any.rs
+++ b/src/action/wait/any.rs
@@ -1,0 +1,125 @@
+use bevy::prelude::World;
+
+use crate::prelude::ActionSeed;
+use crate::runner::{BoxedRunner, CancellationToken, Output, Runner};
+
+/// Wait until the execution of one of the actions is completed.
+///
+/// The output value is the index of the completed action.
+///
+/// # Panics
+///
+/// Panicked if actions is empty.
+///
+/// # Examples
+///
+/// ```no_run
+/// use bevy::prelude::*;
+/// use bevy_flurx::actions;
+/// use bevy_flurx::prelude::*;
+/// use bevy::app::AppExit;
+/// 
+/// Reactor::schedule(|task| async move{
+///     // The output value is the index of the completed action.
+///     let index: usize = task.will(Update, wait::any(actions![
+///         wait::input::just_pressed().with(KeyCode::KeyB),
+///         wait::event::comes::<AppExit>()
+///     ])).await;
+/// });
+/// ```
+pub fn any(actions: impl IntoIterator<Item=ActionSeed> + 'static) -> ActionSeed<(), usize> {
+    ActionSeed::new(move |_, token, output| {
+        let runners = actions
+            .into_iter()
+            .map(|action| action.with(()).into_runner(token.clone(), Output::default()))
+            .collect::<Vec<_>>();
+        if runners.is_empty() {
+            panic!("The length of actions passed to `wait::any` must be greater than 0.")
+        }
+
+        AnyRunner {
+            token,
+            output,
+            runners,
+        }
+    })
+}
+
+struct AnyRunner {
+    token: CancellationToken,
+    output: Output<usize>,
+    runners: Vec<BoxedRunner>,
+}
+
+impl Runner for AnyRunner {
+    fn run(&mut self, world: &mut World) -> bool {
+        if self.token.requested_cancel() {
+            return true;
+        }
+
+        for (i, runner) in self.runners.iter_mut().enumerate() {
+            if runner.run(world) {
+                self.output.replace(i);
+                return true;
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy::app::{AppExit, Startup};
+    use bevy::ecs::event::ManualEventReader;
+    use bevy::prelude::{Commands, Update};
+    use bevy_test_helper::event::DirectEvents;
+
+    use crate::action::{delay, once};
+    use crate::actions;
+    use crate::prelude::wait;
+    use crate::reactor::Reactor;
+    use crate::tests::test_app;
+
+    #[test]
+    fn return_1() {
+        let mut app = test_app();
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                let index = task.will(Update, wait::any(actions![
+                    wait::until(|| false),
+                    once::run(|| {})
+                ])).await;
+                if index == 1 {
+                    task.will(Update, once::event::app_exit()).await;
+                }
+            }));
+        });
+        app.update();
+        app.update();
+        let mut er = ManualEventReader::<AppExit>::default();
+        app.assert_event_comes(&mut er);
+    }
+
+    #[test]
+    fn return_0() {
+        let mut app = test_app();
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                let index = task.will(Update, wait::any(actions![
+                    delay::frames().with(1),
+                    delay::frames().with(3),
+                    wait::until(||false)
+                ])).await;
+                if index == 0 {
+                    task.will(Update, once::event::app_exit()).await;
+                }
+            }));
+        });
+        let mut er = ManualEventReader::<AppExit>::default();
+        app.update();
+        app.assert_event_not_comes(&mut er);
+        
+        app.update();
+        app.assert_event_comes(&mut er);
+    }
+}

--- a/src/action/wait/state.rs
+++ b/src/action/wait/state.rs
@@ -24,7 +24,7 @@ use crate::prelude::ActionSeed;
 /// }
 ///
 /// Reactor::schedule(|task| async move {
-///     task.will(Update, once::state::set().with(Status::Second)).await;
+///     task.will(Update, wait::state::becomes().with(Status::Second)).await;
 /// });
 /// ```
 #[inline(always)]

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -27,11 +27,11 @@ impl<'w, Fun, Fut> ScheduleReactor<'w, Fun, Fut, EntityWorldMut<'w>> for World
         Fut: Future + 'static
 {
     fn spawn_initialized_reactor(&'w mut self, f: Fun) -> EntityWorldMut<'w> {
-        let mut flurx = Reactor::schedule(f);
-        flurx.scheduler.run_sync(WorldPtr::new(self));
+        let mut reactor = Reactor::schedule(f);
+        reactor.scheduler.run_sync(WorldPtr::new(self));
         self.spawn((
             Initialized,
-            flurx
+            reactor
         ))
     }
 }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -94,7 +94,7 @@ mod tests {
     struct Count(usize);
 
     #[test]
-    fn cancel_if_flurx_removed() {
+    fn cancel_if_reactor_removed() {
         let mut app = test_app();
         app.init_resource::<Count>();
         app.add_systems(Startup, |mut commands: Commands| {
@@ -107,8 +107,8 @@ mod tests {
         app.update();
         app.assert_resource_eq(Count(1));
 
-        app.world.run_system_once(|mut cmd: Commands, flurx: Query<Entity, With<Reactor>>| {
-            cmd.entity(flurx.single()).remove::<Reactor>();
+        app.world.run_system_once(|mut cmd: Commands, reactor: Query<Entity, With<Reactor>>| {
+            cmd.entity(reactor.single()).remove::<Reactor>();
         });
         for _ in 0..10 {
             app.update();


### PR DESCRIPTION
`actions!` macros convert the actions to `[ActionSeed; N]`.
This macro is useful for using `wait::any`.

`wait::any` create an action that waits until any action is finished and returns the index of that action.
```rust
    #[test]
    fn return_0() {
        let mut app = test_app();
        app.add_systems(Startup, |mut commands: Commands| {
            commands.spawn(Reactor::schedule(|task| async move {
                let index = task.will(Update, wait::any(actions![
                    delay::frames().with(1),
                    delay::frames().with(3),
                    wait::until(||false)
                ])).await;
                if index == 0 {
                    task.will(Update, once::event::app_exit()).await;
                }
            }));
        });
        let mut er = ManualEventReader::<AppExit>::default();
        app.update();
        app.assert_event_not_comes(&mut er);
        
        app.update();
        app.assert_event_comes(&mut er);
    }
```



