### PR TITLE
fixed delay::frame

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,12 @@ harness = false
 
 [dependencies]
 bevy = { version = "0.13.2", default-features = false }
-flurx = { version = "0.1.4", features = ["sync"] }
+flurx = { version = "0.1.4" }
 futures-polling = "0.1.1"
+pollster = "0.3.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+async-compat = "0.2.3"
 
 [dev-dependencies]
 bevy = { version = "0.13.2" }

--- a/src/action/pipe.rs
+++ b/src/action/pipe.rs
@@ -151,6 +151,7 @@ mod tests {
         app.update();
         app.update();
         app.update();
+        app.update();
         let mut er = ManualEventReader::<AppExit>::default();
         assert!(app.read_last_event(&mut er).is_some());
     }

--- a/src/action/wait/any.rs
+++ b/src/action/wait/any.rs
@@ -120,6 +120,7 @@ mod tests {
         app.assert_event_not_comes(&mut er);
         
         app.update();
+        app.update();
         app.assert_event_comes(&mut er);
     }
 }

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -28,7 +28,7 @@ impl<'w, Fun, Fut> ScheduleReactor<'w, Fun, Fut, EntityWorldMut<'w>> for World
 {
     fn spawn_initialized_reactor(&'w mut self, f: Fun) -> EntityWorldMut<'w> {
         let mut reactor = Reactor::schedule(f);
-        reactor.scheduler.run_sync(WorldPtr::new(self));
+        reactor.run_sync(WorldPtr::new(self));
         self.spawn((
             Initialized,
             reactor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ fn initialize_reactors(
         .query_filtered::<(Entity, &mut Reactor), (Added<Reactor>, Without<Initialized>)>()
         .iter_mut(world) {
         world_ptr.as_mut().entity_mut(entity).insert(Initialized);
-        reactor.scheduler.run_sync(world_ptr);
+        reactor.run_sync(world_ptr);
     }
 }
 
@@ -100,10 +100,10 @@ fn run_reactors(
     for (entity, mut reactor, initialized) in world
         .query::<(Entity, &mut Reactor, Option<&Initialized>)>()
         .iter_mut(world) {
-        reactor.scheduler.run_sync(world_ptr);
+        reactor.run_sync(world_ptr);
         if initialized.is_none() {
             world_ptr.as_mut().entity_mut(entity).insert(Initialized);
-            reactor.scheduler.run_sync(world_ptr);
+            reactor.run_sync(world_ptr);
         }
     }
 }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -24,17 +24,17 @@ pub struct Reactor {
 
 impl Reactor {
     /// Create new [`Reactor`].
-    /// 
+    ///
     /// The scheduled [`Reactor`] will be run and initialized at [`RunReactor`](crate::RunReactor)(and also initialized at [`PostStartup`](bevy::prelude::PostStartup)) ,
-    /// 
+    ///
     /// It is recommended to spawn this structure at [`Update`](bevy::prelude::Update) or [`Startup`](bevy::prelude::Startup)
     /// to reduce the delay until initialization.
-    /// 
+    ///
     /// If you spawn on another [`ScheduleLabel`], 
     /// you can spawn and initialize at the same time by using [`ScheduleReactor`](crate::prelude::ScheduleReactor). 
-    /// 
+    ///
     /// ## Examples
-    /// 
+    ///
     /// ```no_run
     /// use bevy::app::AppExit;
     /// use bevy::prelude::*;
@@ -61,6 +61,19 @@ impl Reactor {
         Self {
             scheduler,
             token,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn run_sync(&mut self, world: WorldPtr) {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            use async_compat::CompatExt;
+            pollster::block_on(self.scheduler.run(world).compat());
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            pollster::block_on(self.scheduler.run(world));
         }
     }
 }


### PR DESCRIPTION
The code below was expected want to wait one frame and then  run the next action, but in reality once::run` had been run on the first frame.

```rust
delay::frames().with(1)
    .then(once::run(||{}))
```