### PR TITLE
Fix/run runners

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 
 use bevy::app::{App, Last, MainScheduleOrder, Plugin, PostStartup};
 use bevy::ecs::schedule::ScheduleLabel;
-use bevy::prelude::{Added, Entity, Without, World};
+use bevy::prelude::{Entity, QueryState, Without, World};
 
 use crate::reactor::{Initialized, Reactor};
 use crate::world_ptr::WorldPtr;
@@ -82,24 +82,22 @@ impl Plugin for FlurxPlugin {
 struct RunReactor;
 
 fn initialize_reactors(
-    world: &mut World
+    world: &mut World,
+    reactors: &mut QueryState<(Entity, &mut Reactor), Without<Initialized>>
 ) {
     let world_ptr = WorldPtr::new(world);
-    for (entity, mut reactor) in world
-        .query_filtered::<(Entity, &mut Reactor), (Added<Reactor>, Without<Initialized>)>()
-        .iter_mut(world) {
+    for (entity, mut reactor) in reactors.iter_mut(world) {
         world_ptr.as_mut().entity_mut(entity).insert(Initialized);
         reactor.run_sync(world_ptr);
     }
 }
 
 fn run_reactors(
-    world: &mut World
+    world: &mut World,
+    reactors: &mut QueryState<(Entity, &mut Reactor, Option<&Initialized>)>
 ) {
     let world_ptr = WorldPtr::new(world);
-    for (entity, mut reactor, initialized) in world
-        .query::<(Entity, &mut Reactor, Option<&Initialized>)>()
-        .iter_mut(world) {
+    for (entity, mut reactor, initialized) in reactors.iter_mut(world) {
         reactor.run_sync(world_ptr);
         if initialized.is_none() {
             world_ptr.as_mut().entity_mut(entity).insert(Initialized);

--- a/src/task.rs
+++ b/src/task.rs
@@ -123,6 +123,7 @@ mod tests {
         app.update();
         assert!(app.world.get_non_send_resource::<AppExit>().is_none());
         app.update();
+        app.update();
         assert!(app.world.get_non_send_resource::<AppExit>().is_some());
     }
 }


### PR DESCRIPTION
The benchmark below is simple count-up on [cmp_countup.rs](https://github.com/not-elm/bevy_flurx/blob/main/benches/cmp_countup.rs)

Measurements were taken three times each of before and after modification.

previous
```
with_flurx count: 10000 time:   [121.61 ms 125.48 ms 129.59 ms]
with_flurx count: 10000 time:   [126.40 ms 129.75 ms 133.52 ms]
with_flurx count: 10000 time:   [121.18 ms 123.19 ms 125.40 ms]
```

current
```
with_flurx count: 10000 time:   [102.41 ms 105.82 ms 109.92 ms]
with_flurx count: 10000 time:   [98.015 ms 98.870 ms 99.815 ms]
with_flurx count: 10000 time:   [109.00 ms 111.70 ms 115.01 ms]
```

The reason is this pr is marked FIX is because this work caused one of the existing test  to fail.

```rust
#[test]
fn run() {
    let mut app = test_app();
    app.add_systems(Startup, |mut commands: Commands| {
        commands.spawn(Reactor::schedule(|task| async move {
            let event_task = task.run(First, wait::event::read::<AppExit>()).await;
            task.will(Update, once::event::send().with(AppExit)).await;
            event_task.await;
            task.will(Update, once::non_send::insert().with(AppExit)).await;
        }));
    });

    app.update();
    assert!(app.world.get_non_send_resource::<AppExit>().is_none());
    app.update();
    assert!(app.world.get_non_send_resource::<AppExit>().is_some()); // failed!
}
```

However, I don't think it's a bug because the behavior below should be correct according to the current specifications.
 
```rust
#[test]
fn run() {
    let mut app = test_app();
    app.add_systems(Startup, |mut commands: Commands| {
        commands.spawn(Reactor::schedule(|task| async move {
            let event_task = task.run(First, wait::event::read::<AppExit>()).await;
            task.will(Update, once::event::send().with(AppExit)).await;
            event_task.await;
            task.will(Update, once::non_send::insert().with(AppExit)).await;
        }));
    });

    app.update();
    assert!(app.world.get_non_send_resource::<AppExit>().is_none());
    app.update();
    app.update();
    assert!(app.world.get_non_send_resource::<AppExit>().is_some()); // failed!
}
```