### PR TITLE
Add wait::all action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Install alsa and udev
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/src/action.rs
+++ b/src/action.rs
@@ -86,6 +86,20 @@ impl<Out> From<ActionSeed<(), Out>> for Action<(), Out>
 }
 
 /// Creates a \[[`ActionSeed`]; N\] containing the omitted actions.
+/// 
+/// # Examples
+/// 
+/// ```no_run
+/// use bevy::app::AppExit;
+/// use bevy_flurx::actions;
+/// use bevy_flurx::prelude::*;
+///
+/// let actions: [ActionSeed; 3] = actions![
+///     once::run(||{}),
+///     delay::frames().with(3),
+///     wait::event::comes::<AppExit>()
+/// ];
+/// ```
 #[macro_export]
 macro_rules! actions {
     () => (

--- a/src/action/wait.rs
+++ b/src/action/wait.rs
@@ -5,6 +5,7 @@
 //! - [`wait::output`]
 //! - [`wait::both`]
 //! - [`wait::until`]
+//! - [`wait::all`](crate::prelude::wait::all())
 //! - [`wait_all!`](crate::wait_all)
 //! - [`wait::either`]
 //! - [`wait::event`]
@@ -29,8 +30,7 @@ pub mod event;
 pub mod input;
 pub mod state;
 pub mod switch;
-#[allow(missing_docs)]
-pub mod all;
+pub use all::{all, private};
 #[cfg(feature = "audio")]
 pub mod audio;
 #[path = "wait/either.rs"]
@@ -39,7 +39,7 @@ mod _either;
 mod _both;
 #[path = "wait/any.rs"]
 mod _any;
-
+mod all;
 
 /// Run until it returns [`Option::Some`].
 /// The contents of Some will be return value of the task.

--- a/src/action/wait/all.rs
+++ b/src/action/wait/all.rs
@@ -1,6 +1,72 @@
+use bevy::prelude::World;
+
+use crate::prelude::{ActionSeed, Output, Runner};
+use crate::runner::{BoxedRunner, CancellationToken};
+
+/// Wait until all the actions are completed.
+///
+/// The output value of this function is `()`.
+/// If you need the outputs, consider using [`wait_all!`](crate::wait_all) instead. 
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::time::Duration;
+/// use bevy::prelude::*;
+/// use bevy_flurx::actions;
+/// use bevy_flurx::prelude::*;
+///
+/// Reactor::schedule(|task| async move{
+///     task.will(Update, wait::all().with(actions![
+///         once::run(||{}),
+///         delay::time().with(Duration::from_millis(300)),
+///         wait::input::just_pressed().with(KeyCode::KeyA)
+///     ])).await;
+/// });
+/// ```
+pub fn all<Actions>() -> ActionSeed<Actions>
+    where
+        Actions: IntoIterator<Item=ActionSeed> + 'static
+{
+    ActionSeed::new(|actions: Actions, token, output| {
+        AllRunner {
+            runners: actions
+                .into_iter()
+                .map(|seed| seed.with(()).into_runner(token.clone(), Output::default()))
+                .collect(),
+            token,
+            output,
+        }
+    })
+}
+
+struct AllRunner {
+    token: CancellationToken,
+    output: Output<()>,
+    runners: Vec<BoxedRunner>,
+}
+
+impl Runner for AllRunner {
+    fn run(&mut self, world: &mut World) -> bool {
+        if self.token.requested_cancel() {
+            return true;
+        }
+        self.runners.retain_mut(|r| !r.run(world));
+        if self.runners.is_empty() {
+            self.output.replace(());
+            true
+        } else {
+            false
+        }
+    }
+}
+
 /// Wait until all tasks done.
 ///
 /// The return value type is tuple, its length is equal to the number of as passed tasks.
+///
+/// If you don't need the outputs of the actions or want to pass a collection of actions,
+/// consider using [`wait::all`](crate::prelude::wait::all()) instead.
 ///
 /// ## Examples
 ///
@@ -38,10 +104,10 @@ macro_rules! wait_all {
     ($action1: expr, $action2: expr $(,$action: expr)*$(,)?)  => {
         {
             #[allow(unused)]
-            use $crate::prelude::wait::all::private::CreateBothAction;
+            use $crate::prelude::wait::private::CreateBothAction;
             let a = $crate::action::wait::both($action1, $action2);
             $(
-            let a = $crate::prelude::wait::all::private::FlatBothRunner::action(a, $action.into());
+            let a = $crate::prelude::wait::private::FlatBothRunner::action(a, $action.into());
             )*
             a
         }
@@ -147,11 +213,57 @@ mod tests {
     use bevy::app::{AppExit, Startup, Update};
     use bevy::ecs::system::RunSystemOnce;
     use bevy::prelude::{Commands, EventWriter, Local};
-    use bevy_test_helper::event::{TestEvent1, TestEvent2};
+    use bevy_test_helper::event::{DirectEvents, TestEvent1, TestEvent2};
+    use bevy_test_helper::resource::count::Count;
+    use bevy_test_helper::resource::DirectResourceControl;
+    use crate::action::delay;
+    use crate::actions;
 
-    use crate::prelude::{once, Then, wait};
+    use crate::prelude::{once, Pipe, Then, wait};
     use crate::reactor::Reactor;
-    use crate::tests::test_app;
+    use crate::test_util::SpawnReactor;
+    use crate::tests::{decrement_count, exit_reader, increment_count, test_app};
+
+    #[test]
+    fn wai_all_actions() {
+        let mut app = test_app();
+        app.spawn_reactor(|task| async move {
+            task.will(Update, {
+                once::run(|| [
+                    increment_count(),
+                    increment_count(),
+                    decrement_count()
+                ])
+                    .pipe(wait::all())
+            }).await;
+        });
+        app.update();
+        app.assert_resource_eq(Count(1));
+    }
+    
+    #[test]
+    fn with_delay_1frame() {
+        let mut app = test_app();
+        app.spawn_reactor(|task| async move {
+            task.will(Update, {
+                once::run(|| actions![
+                    increment_count(),
+                    delay::frames().with(1),
+                    increment_count()
+                ])
+                    .pipe(wait::all())
+                    .then(once::event::app_exit())
+            }).await;
+        });
+        let mut er = exit_reader();
+        app.update();
+        app.assert_resource_eq(Count(2));
+        app.assert_event_not_comes(&mut er);
+        
+        app.update();
+        app.assert_resource_eq(Count(2));
+        app.assert_event_comes(&mut er);
+    }
 
     #[test]
     fn wait_all() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@ mod world_ptr;
 mod reactor;
 mod selector;
 
+#[cfg(test)]
+mod test_util;
+
 /// Provides the async systems.
 pub struct FlurxPlugin;
 

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,25 @@
+use std::future::Future;
+
+use bevy::app::App;
+use bevy::prelude::World;
+
+use crate::prelude::Reactor;
+use crate::task::ReactiveTask;
+
+pub trait SpawnReactor {
+    fn spawn_reactor<F>(&mut self, f: impl FnOnce(ReactiveTask) -> F + 'static)
+        where
+            F: Future;
+}
+
+impl SpawnReactor for World {
+    fn spawn_reactor<F>(&mut self, f: impl FnOnce(ReactiveTask) -> F + 'static) where F: Future {
+        self.spawn(Reactor::schedule(f));
+    }
+}
+
+impl SpawnReactor for App {
+    fn spawn_reactor<F>(&mut self, f: impl FnOnce(ReactiveTask) -> F + 'static) where F: Future {
+        self.world.spawn_reactor(f);
+    }
+}


### PR DESCRIPTION
This action waits until all the actions are completed.
Similar to `wait_all!`, but this action returns no output.
The advantage is that it is faster than wait_all and can pass collections.

```rust

wait::all().with(actions![
    wait::input::just_pressed().with(KeyCode::KeyB),
    wait::event::comes::<AppExit>()
]);
```