### PR TITLE
Breaking Change: Fixed around cancellations

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -86,6 +86,20 @@ impl<Out> From<ActionSeed<(), Out>> for Action<(), Out>
 }
 
 /// Creates a \[[`ActionSeed`]; N\] containing the omitted actions.
+/// 
+/// # Examples
+/// 
+/// ```no_run
+/// use bevy::app::AppExit;
+/// use bevy_flurx::actions;
+/// use bevy_flurx::prelude::*;
+///
+/// let actions: [ActionSeed; 3] = actions![
+///     once::run(||{}),
+///     delay::frames().with(3),
+///     wait::event::comes::<AppExit>()
+/// ];
+/// ```
 #[macro_export]
 macro_rules! actions {
     () => (

--- a/src/action.rs
+++ b/src/action.rs
@@ -40,8 +40,8 @@ pub use map::Map;
 pub use record::redo;
 pub use remake::Remake;
 
-use crate::prelude::ActionSeed;
-use crate::runner::{BoxedRunner, CancellationToken, Output};
+use crate::prelude::{ActionSeed};
+use crate::runner::{BoxedRunner, Output};
 
 pub mod once;
 pub mod wait;
@@ -69,9 +69,9 @@ impl<I1, O1> Action<I1, O1>
         I1: 'static,
         O1: 'static
 {
-    #[inline]
-    pub(crate) fn into_runner(self, token: CancellationToken, output: Output<O1>) -> BoxedRunner {
-        self.1.create_runner(self.0, token, output)
+    #[inline(always)]
+    pub(crate) fn into_runner(self, output: Output<O1>) -> BoxedRunner {
+        self.1.create_runner(self.0, output)
     }
 }
 
@@ -86,9 +86,9 @@ impl<Out> From<ActionSeed<(), Out>> for Action<(), Out>
 }
 
 /// Creates a \[[`ActionSeed`]; N\] containing the omitted actions.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```no_run
 /// use bevy::app::AppExit;
 /// use bevy_flurx::actions;

--- a/src/action/map.rs
+++ b/src/action/map.rs
@@ -1,7 +1,8 @@
 use bevy::prelude::World;
 
 use crate::action::remake::Remake;
-use crate::runner::{BoxedRunner, CancellationToken, Output, Runner};
+use crate::prelude::CancellationToken;
+use crate::runner::{BoxedRunner, Output, Runner};
 
 /// Maps an `Action<I1, O1>` to `Action<I1, O2>` or `ActionSeed<I1, O1>` to `ActionSeed<I1, O2>` by
 /// applying function.
@@ -59,11 +60,10 @@ impl<I, O, O2, A, Re> Map<I, O, O2, A> for Re
 {
     #[inline]
     fn map(self, f: impl FnOnce(O) -> O2 + 'static) -> A {
-        self.remake(|r1, o1, token, output| {
+        self.remake(|r1, o1, output| {
             MapRunner {
                 r1,
                 o1,
-                token,
                 output,
                 map: Some(f),
             }
@@ -72,7 +72,6 @@ impl<I, O, O2, A, Re> Map<I, O, O2, A> for Re
 }
 
 struct MapRunner<O1, O2, F> {
-    token: CancellationToken,
     r1: BoxedRunner,
     o1: Output<O1>,
     output: Output<O2>,
@@ -82,17 +81,19 @@ struct MapRunner<O1, O2, F> {
 impl<O1, O2, F> Runner for MapRunner<O1, O2, F>
     where F: FnOnce(O1) -> O2 + 'static
 {
-    fn run(&mut self, world: &mut World) -> bool {
-        if self.token.requested_cancel() {
-            return true;
-        }
-        self.r1.run(world);
+    fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool {
+        self.r1.run(world, token);
         if let Some(o) = self.o1.take() {
-            self.output.replace(self.map.take().unwrap()(o));
+            self.output.set(self.map.take().unwrap()(o));
             true
         } else {
             false
         }
+    }
+
+    #[inline]
+    fn on_cancelled(&mut self, world: &mut World) {
+        self.r1.on_cancelled(world);
     }
 }
 

--- a/src/action/record/track.rs
+++ b/src/action/record/track.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::action::{Action, Map};
 use crate::prelude::{ActionSeed, Omit, OmitInput};
-use crate::runner::{BoxedRunner, CancellationToken, Output};
+use crate::runner::{BoxedRunner, Output};
 
 /// Represents the track of act.
 pub struct Track<Act> {
@@ -19,8 +19,8 @@ impl<Act> Track<Act>
         Act: Send + Sync + 'static
 {
     #[inline]
-    pub(crate) fn create_runner(&self, token: CancellationToken, output: Output<Option<ActionSeed>>) -> BoxedRunner {
-        (self.rollback.0)().into_runner(token, output)
+    pub(crate) fn create_runner(&self, output: Output<Option<ActionSeed>>) -> BoxedRunner {
+        (self.rollback.0)().into_runner(output)
     }
 }
 

--- a/src/action/remake.rs
+++ b/src/action/remake.rs
@@ -1,13 +1,13 @@
 use crate::action::Action;
 use crate::prelude::{ActionSeed, Output, Runner};
-use crate::runner::{BoxedRunner, CancellationToken};
+use crate::runner::BoxedRunner;
 
 /// Remake a new action base on itself [`Runner`] and [`Output`].
 pub trait Remake<I1, O1, O2, ActionOrSeed> {
     /// Remake a new action base on itself [`Runner`] and [`Output`].
     fn remake<F, R>(self, f: F) -> ActionOrSeed
         where
-            F: FnOnce(BoxedRunner, Output<O1>, CancellationToken, Output<O2>) -> R + 'static,
+            F: FnOnce(BoxedRunner, Output<O1>, Output<O2>) -> R + 'static,
             R: Runner + 'static;
 }
 
@@ -20,13 +20,13 @@ impl<I1, O1, O2> Remake<I1, O1, O2, ActionSeed<I1, O2>> for ActionSeed<I1, O1>
     #[inline]
     fn remake<F, R>(self, f: F) -> ActionSeed<I1, O2>
         where
-            F: FnOnce(BoxedRunner, Output<O1>, CancellationToken, Output<O2>) -> R + 'static,
+            F: FnOnce(BoxedRunner, Output<O1>, Output<O2>) -> R + 'static,
             R: Runner + 'static,
     {
-        ActionSeed::new(|input, token, output| {
+        ActionSeed::new(|input, output| {
             let o1 = Output::default();
-            let runner = self.create_runner(input, token.clone(), o1.clone());
-            f(runner, o1, token, output)
+            let runner = self.create_runner(input, o1.clone());
+            f(runner, o1, output)
         })
     }
 }
@@ -40,7 +40,7 @@ impl<I1, O1, O2> Remake<I1, O1, O2, Action<I1, O2>> for Action<I1, O1>
     #[inline]
     fn remake<F, R>(self, f: F) -> Action<I1, O2>
         where
-            F: FnOnce(BoxedRunner, Output<O1>, CancellationToken, Output<O2>) -> R + 'static,
+            F: FnOnce(BoxedRunner, Output<O1>, Output<O2>) -> R + 'static,
             R: Runner + 'static,
     {
         self.1.remake(f).with(self.0)

--- a/src/action/seed.rs
+++ b/src/action/seed.rs
@@ -4,9 +4,9 @@
 use std::marker::PhantomData;
 
 use crate::action::Action;
-use crate::runner::{BoxedRunner, CancellationToken, Output, Runner};
+use crate::runner::{BoxedRunner, Output, Runner};
 
-/// If [`In`](bevy::prelude::In) type of the struct implements this is `()`, 
+/// If [`In`](bevy::prelude::In) type of the struct implements this is `()`,
 /// its struct also implements Into<[`Action`]> automatically.
 ///
 /// Otherwise, to convert to the action,
@@ -14,7 +14,7 @@ use crate::runner::{BoxedRunner, CancellationToken, Output, Runner};
 ///
 /// [`Action`]: crate::prelude::Action
 /// [`Pipe::pipe`]: crate::prelude::Pipe::pipe
-pub struct ActionSeed<I = (), O = ()>(Box<dyn FnOnce(I, CancellationToken, Output<O>) -> BoxedRunner>, PhantomData<I>);
+pub struct ActionSeed<I = (), O = ()>(Box<dyn FnOnce(I, Output<O>) -> BoxedRunner>, PhantomData<I>);
 
 impl<I, O> ActionSeed<I, O>
     where
@@ -23,12 +23,12 @@ impl<I, O> ActionSeed<I, O>
 {
     /// Create the [`ActionSeed`].
     #[inline]
-    pub fn new<R>(f: impl FnOnce(I, CancellationToken, Output<O>) -> R + 'static) -> ActionSeed<I, O>
+    pub fn new<R>(f: impl FnOnce(I, Output<O>) -> R + 'static) -> ActionSeed<I, O>
         where
             R: Runner + 'static
     {
-        ActionSeed(Box::new(move |input, token, output| {
-            BoxedRunner::new(f(input, token, output))
+        ActionSeed(Box::new(move |input, output| {
+            BoxedRunner::new(f(input, output))
         }), PhantomData)
     }
 
@@ -54,8 +54,8 @@ impl<I, O> ActionSeed<I, O>
             I2: 'static,
             A: Into<Action<I2, O>>
     {
-        ActionSeed::from(|input, token, output|{
-            f(input).into().into_runner(token, output)
+        ActionSeed::from(|input, output| {
+            f(input).into().into_runner(output)
         })
     }
 
@@ -67,15 +67,15 @@ impl<I, O> ActionSeed<I, O>
         Action(input, self)
     }
 
-    #[inline]
-    pub(crate) fn create_runner(self, input: I, token: CancellationToken, output: Output<O>) -> BoxedRunner {
-        (self.0)(input, token, output)
+    #[inline(always)]
+    pub(crate) fn create_runner(self, input: I, output: Output<O>) -> BoxedRunner {
+        (self.0)(input, output)
     }
 }
 
 impl<I, O, F> From<F> for ActionSeed<I, O>
     where
-        F: FnOnce(I, CancellationToken, Output<O>) -> BoxedRunner + 'static
+        F: FnOnce(I, Output<O>) -> BoxedRunner + 'static
 {
     #[inline]
     fn from(value: F) -> Self {

--- a/src/action/through.rs
+++ b/src/action/through.rs
@@ -11,8 +11,8 @@ use bevy::prelude::World;
 
 use crate::action::pipe::Pipe;
 use crate::action::seed::ActionSeed;
-use crate::prelude::Action;
-use crate::runner::{BoxedRunner, CancellationToken, Output, Runner};
+use crate::prelude::{Action, CancellationToken};
+use crate::runner::{BoxedRunner, Output, Runner};
 
 /// This function is used when you want to insert some kind of action,
 /// such as a delay, between the action that sends output and the action that receives it.
@@ -43,12 +43,11 @@ pub fn through<V, I, O>(action: impl Into<Action<I, O>> + 'static) -> ActionSeed
         I: 'static,
         O: 'static
 {
-    ActionSeed::new(|input, token, output| {
+    ActionSeed::new(|input, output| {
         ThroughRunner {
             value: Some(input),
             output,
-            inner: action.into().into_runner(token.clone(), Output::default()),
-            token,
+            inner: action.into().into_runner(Output::default()),
         }
     })
 }
@@ -117,24 +116,24 @@ struct ThroughRunner<V> {
     value: Option<V>,
     output: Output<V>,
     inner: BoxedRunner,
-    token: CancellationToken,
 }
 
 impl<V> Runner for ThroughRunner<V>
     where
         V: 'static,
 {
-    fn run(&mut self, world: &mut World) -> bool {
-        if self.token.requested_cancel() {
-            return true;
-        }
-
-        if self.inner.run(world) {
-            self.output.replace(self.value.take().unwrap());
+    fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool {
+        if self.inner.run(world, token) {
+            self.output.set(self.value.take().unwrap());
             true
         } else {
             false
         }
+    }
+
+    #[inline]
+    fn on_cancelled(&mut self, world: &mut World) {
+        self.inner.on_cancelled(world);
     }
 }
 

--- a/src/action/wait.rs
+++ b/src/action/wait.rs
@@ -5,6 +5,7 @@
 //! - [`wait::output`]
 //! - [`wait::both`]
 //! - [`wait::until`]
+//! - [`wait::all`](crate::prelude::wait::all())
 //! - [`wait_all!`](crate::wait_all)
 //! - [`wait::either`]
 //! - [`wait::event`]
@@ -29,8 +30,7 @@ pub mod event;
 pub mod input;
 pub mod state;
 pub mod switch;
-#[allow(missing_docs)]
-pub mod all;
+pub use all::{all, private};
 #[cfg(feature = "audio")]
 pub mod audio;
 #[path = "wait/either.rs"]
@@ -39,7 +39,7 @@ mod _either;
 mod _both;
 #[path = "wait/any.rs"]
 mod _any;
-
+mod all;
 
 /// Run until it returns [`Option::Some`].
 /// The contents of Some will be return value of the task.

--- a/src/action/wait/all.rs
+++ b/src/action/wait/all.rs
@@ -28,35 +28,36 @@ pub fn all<Actions>() -> ActionSeed<Actions>
     where
         Actions: IntoIterator<Item=ActionSeed> + 'static
 {
-    ActionSeed::new(|actions: Actions, token, output| {
+    ActionSeed::new(|actions: Actions, output| {
         AllRunner {
             runners: actions
                 .into_iter()
-                .map(|seed| seed.with(()).into_runner(token.clone(), Output::default()))
+                .map(|seed| seed.with(()).into_runner(Output::default()))
                 .collect(),
-            token,
             output,
         }
     })
 }
 
 struct AllRunner {
-    token: CancellationToken,
     output: Output<()>,
     runners: Vec<BoxedRunner>,
 }
 
 impl Runner for AllRunner {
-    fn run(&mut self, world: &mut World) -> bool {
-        if self.token.requested_cancel() {
-            return true;
-        }
-        self.runners.retain_mut(|r| !r.run(world));
+    fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool {
+        self.runners.retain_mut(|r| !r.run(world, token));
         if self.runners.is_empty() {
-            self.output.replace(());
+            self.output.set(());
             true
         } else {
             false
+        }
+    }
+
+    fn on_cancelled(&mut self, world: &mut World) {
+        for runner in self.runners.iter_mut() {
+            runner.on_cancelled(world);
         }
     }
 }
@@ -121,11 +122,10 @@ pub mod private {
 
     use crate::action::Action;
     use crate::prelude::ActionSeed;
-    use crate::runner::{BoxedRunner, CancellationToken, Output, Runner};
+    use crate::runner::{BoxedRunner, Output, Runner};
     use crate::runner::macros::impl_tuple_runner;
 
     pub struct FlatBothRunner<I1, I2, O1, O2, O> {
-        token: CancellationToken,
         o1: Output<O1>,
         o2: Output<O2>,
         r1: BoxedRunner,
@@ -154,16 +154,15 @@ pub mod private {
                 ) -> Action<(I1, I2), ($($lhs_out,)* O2)> {
                     let Action(i1, s1) = a1.into();
                     let Action(i2, s2) = a2.into();
-                    ActionSeed::new(|input: (I1, I2), token, output|{
+                    ActionSeed::new(|input: (I1, I2), output|{
                         let o1 = Output::default();
                         let o2 = Output::default();
                         Self {
                             output,
-                            r1: s1.with(input.0).into_runner(token.clone(), o1.clone()),
-                            r2: s2.with(input.1).into_runner(token.clone(), o2.clone()),
+                            r1: s1.with(input.0).into_runner(o1.clone()),
+                            r2: s2.with(input.1).into_runner(o2.clone()),
                             o1,
                             o2,
-                            token,
                             _m: PhantomData
                         }
                     })
@@ -179,27 +178,29 @@ pub mod private {
                     O2: 'static,
             {
                 #[allow(non_snake_case)]
-                  fn run(&mut self, world: &mut bevy::prelude::World) -> bool {
-                    if self.token.requested_cancel(){
-                        return true;
-                    }
+                  fn run(&mut self, world: &mut bevy::prelude::World, token: &$crate::prelude::CancellationToken) -> bool {
                     if self.o1.is_none(){
-                        self.r1.run(world);
+                        self.r1.run(world, token);
                     }
                     if self.o2.is_none(){
-                        self.r2.run(world);
+                        self.r2.run(world, token);
                     }
                     if let Some(($($lhs_out,)*)) = self.o1.take(){
                         if let Some(out2) = self.o2.take(){
-                            self.output.replace(($($lhs_out,)* out2));
+                            self.output.set(($($lhs_out,)* out2));
                             true
                         }else{
-                            self.o1.replace(($($lhs_out,)*));
+                            self.o1.set(($($lhs_out,)*));
                             false
                         }
                     }else{
                         false
                     }
+                }
+
+                fn on_cancelled(&mut self, world: &mut bevy::ecs::world::World){
+                    self.r1.on_cancelled(world);
+                    self.r2.on_cancelled(world);
                 }
             }
         };
@@ -216,9 +217,9 @@ mod tests {
     use bevy_test_helper::event::{DirectEvents, TestEvent1, TestEvent2};
     use bevy_test_helper::resource::count::Count;
     use bevy_test_helper::resource::DirectResourceControl;
+
     use crate::action::delay;
     use crate::actions;
-
     use crate::prelude::{once, Pipe, Then, wait};
     use crate::reactor::Reactor;
     use crate::test_util::SpawnReactor;
@@ -240,7 +241,7 @@ mod tests {
         app.update();
         app.assert_resource_eq(Count(1));
     }
-    
+
     #[test]
     fn with_delay_1frame() {
         let mut app = test_app();
@@ -259,7 +260,7 @@ mod tests {
         app.update();
         app.assert_resource_eq(Count(2));
         app.assert_event_not_comes(&mut er);
-        
+
         app.update();
         app.assert_resource_eq(Count(2));
         app.assert_event_comes(&mut er);

--- a/src/action/wait/all.rs
+++ b/src/action/wait/all.rs
@@ -1,6 +1,72 @@
+use bevy::prelude::World;
+
+use crate::prelude::{ActionSeed, Output, Runner};
+use crate::runner::{BoxedRunner, CancellationToken};
+
+/// Wait until all the actions are completed.
+///
+/// The output value of this function is `()`.
+/// If you need the outputs, consider using [`wait_all!`](crate::wait_all) instead. 
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::time::Duration;
+/// use bevy::prelude::*;
+/// use bevy_flurx::actions;
+/// use bevy_flurx::prelude::*;
+///
+/// Reactor::schedule(|task| async move{
+///     task.will(Update, wait::all().with(actions![
+///         once::run(||{}),
+///         delay::time().with(Duration::from_millis(300)),
+///         wait::input::just_pressed().with(KeyCode::KeyA)
+///     ])).await;
+/// });
+/// ```
+pub fn all<Actions>() -> ActionSeed<Actions>
+    where
+        Actions: IntoIterator<Item=ActionSeed> + 'static
+{
+    ActionSeed::new(|actions: Actions, token, output| {
+        AllRunner {
+            runners: actions
+                .into_iter()
+                .map(|seed| seed.with(()).into_runner(token.clone(), Output::default()))
+                .collect(),
+            token,
+            output,
+        }
+    })
+}
+
+struct AllRunner {
+    token: CancellationToken,
+    output: Output<()>,
+    runners: Vec<BoxedRunner>,
+}
+
+impl Runner for AllRunner {
+    fn run(&mut self, world: &mut World) -> bool {
+        if self.token.requested_cancel() {
+            return true;
+        }
+        self.runners.retain_mut(|r| !r.run(world));
+        if self.runners.is_empty() {
+            self.output.replace(());
+            true
+        } else {
+            false
+        }
+    }
+}
+
 /// Wait until all tasks done.
 ///
 /// The return value type is tuple, its length is equal to the number of as passed tasks.
+///
+/// If you don't need the outputs of the actions or want to pass a collection of actions,
+/// consider using [`wait::all`](crate::prelude::wait::all()) instead.
 ///
 /// ## Examples
 ///
@@ -38,10 +104,10 @@ macro_rules! wait_all {
     ($action1: expr, $action2: expr $(,$action: expr)*$(,)?)  => {
         {
             #[allow(unused)]
-            use $crate::prelude::wait::all::private::CreateBothAction;
+            use $crate::prelude::wait::private::CreateBothAction;
             let a = $crate::action::wait::both($action1, $action2);
             $(
-            let a = $crate::prelude::wait::all::private::FlatBothRunner::action(a, $action.into());
+            let a = $crate::prelude::wait::private::FlatBothRunner::action(a, $action.into());
             )*
             a
         }
@@ -147,11 +213,57 @@ mod tests {
     use bevy::app::{AppExit, Startup, Update};
     use bevy::ecs::system::RunSystemOnce;
     use bevy::prelude::{Commands, EventWriter, Local};
-    use bevy_test_helper::event::{TestEvent1, TestEvent2};
+    use bevy_test_helper::event::{DirectEvents, TestEvent1, TestEvent2};
+    use bevy_test_helper::resource::count::Count;
+    use bevy_test_helper::resource::DirectResourceControl;
+    use crate::action::delay;
+    use crate::actions;
 
-    use crate::prelude::{once, Then, wait};
+    use crate::prelude::{once, Pipe, Then, wait};
     use crate::reactor::Reactor;
-    use crate::tests::test_app;
+    use crate::test_util::SpawnReactor;
+    use crate::tests::{decrement_count, exit_reader, increment_count, test_app};
+
+    #[test]
+    fn wai_all_actions() {
+        let mut app = test_app();
+        app.spawn_reactor(|task| async move {
+            task.will(Update, {
+                once::run(|| [
+                    increment_count(),
+                    increment_count(),
+                    decrement_count()
+                ])
+                    .pipe(wait::all())
+            }).await;
+        });
+        app.update();
+        app.assert_resource_eq(Count(1));
+    }
+    
+    #[test]
+    fn with_delay_1frame() {
+        let mut app = test_app();
+        app.spawn_reactor(|task| async move {
+            task.will(Update, {
+                once::run(|| actions![
+                    increment_count(),
+                    delay::frames().with(1),
+                    increment_count()
+                ])
+                    .pipe(wait::all())
+                    .then(once::event::app_exit())
+            }).await;
+        });
+        let mut er = exit_reader();
+        app.update();
+        app.assert_resource_eq(Count(2));
+        app.assert_event_not_comes(&mut er);
+        
+        app.update();
+        app.assert_resource_eq(Count(2));
+        app.assert_event_comes(&mut er);
+    }
 
     #[test]
     fn wait_all() {

--- a/src/action/wait/both.rs
+++ b/src/action/wait/both.rs
@@ -33,17 +33,16 @@ pub fn both<LI, LO, RI, RO>(
 {
     let Action(i1, s1) = lhs.into();
     let Action(i2, s2) = rhs.into();
-    ActionSeed::new(move |input: (LI, RI), token, output| {
+    ActionSeed::new(move |input: (LI, RI), output| {
         let o1 = Output::default();
         let o2 = Output::default();
 
         BothRunner {
-            r1: s1.with(input.0).into_runner(token.clone(), o1.clone()),
-            r2: s2.with(input.1).into_runner(token.clone(), o2.clone()),
+            r1: s1.with(input.0).into_runner(o1.clone()),
+            r2: s2.with(input.1).into_runner(o2.clone()),
             o1,
             o2,
-            output,
-            token,
+            output
         }
     })
         .with((i1, i2))
@@ -54,8 +53,7 @@ struct BothRunner<O1, O2> {
     r2: BoxedRunner,
     o1: Output<O1>,
     o2: Output<O2>,
-    output: Output<(O1, O2)>,
-    token: CancellationToken,
+    output: Output<(O1, O2)>
 }
 
 impl<O1, O2> Runner for BothRunner<O1, O2>
@@ -63,17 +61,18 @@ impl<O1, O2> Runner for BothRunner<O1, O2>
         O1: 'static,
         O2: 'static
 {
-    fn run(&mut self, world: &mut World) -> bool {
-        if self.token.requested_cancel() {
-            return true;
-        }
-
+    fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool {
         if self.o1.is_none() {
-            self.r1.run(world);
+            self.r1.run(world, token);
         }
         if self.o2.is_none() {
-            self.r2.run(world);
+            self.r2.run(world, token);
         }
         output_combine!(&self.o1, &self.o2, self.output)
+    }
+
+    fn on_cancelled(&mut self, world: &mut World) {
+        self.r1.on_cancelled(world);
+        self.r2.on_cancelled(world);
     }
 }

--- a/src/action/wait/either.rs
+++ b/src/action/wait/either.rs
@@ -64,16 +64,15 @@ pub fn either<LI, LO, RI, RO, >(
 {
     let Action(li, ls) = lhs.into();
     let Action(ri, rs) = rhs.into();
-    ActionSeed::new(move |input: (LI, RI), token, output| {
+    ActionSeed::new(move |input: (LI, RI), output| {
         let o1 = Output::default();
         let o2 = Output::default();
         EitherRunner {
-            r1: ls.with(input.0).into_runner(token.clone(), o1.clone()),
-            r2: rs.with(input.1).into_runner(token.clone(), o2.clone()),
+            r1: ls.with(input.0).into_runner(o1.clone()),
+            r2: rs.with(input.1).into_runner(o2.clone()),
             o1,
             o2,
-            output,
-            token,
+            output
         }
     })
         .with((li, ri))
@@ -84,7 +83,6 @@ struct EitherRunner<O1, O2> {
     r2: BoxedRunner,
     o1: Output<O1>,
     o2: Output<O2>,
-    token: CancellationToken,
     output: Output<Either<O1, O2>>,
 }
 
@@ -93,23 +91,24 @@ impl<O1, O2> Runner for EitherRunner<O1, O2>
         O1: 'static,
         O2: 'static,
 {
-    fn run(&mut self, world: &mut World) -> bool {
-        if self.token.requested_cancel() {
-            return true;
-        }
-
-        self.r1.run(world);
+    fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool {
+        self.r1.run(world, token);
         if let Some(lhs) = self.o1.take() {
-            self.output.replace(Either::Left(lhs));
+            self.output.set(Either::Left(lhs));
             return true;
         }
-        self.r2.run(world);
+        self.r2.run(world, token);
         if let Some(rhs) = self.o2.take() {
-            self.output.replace(Either::Right(rhs));
+            self.output.set(Either::Right(rhs));
             true
         } else {
             false
         }
+    }
+
+    fn on_cancelled(&mut self, world: &mut World) {
+        self.r1.on_cancelled(world);
+        self.r2.on_cancelled(world);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@ mod world_ptr;
 mod reactor;
 mod selector;
 
+#[cfg(test)]
+mod test_util;
+
 /// Provides the async systems.
 pub struct FlurxPlugin;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub mod prelude {
         extension::ScheduleReactor,
         FlurxPlugin,
         reactor::Reactor,
-        runner::{Output, Runner},
+        runner::*,
         task::ReactiveTask,
     };
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12,6 +12,7 @@ pub use output::Output;
 mod output;
 mod cancellation_token;
 
+
 /// The structure that implements [`Runner`] is given [`Output`],
 /// if the system termination condition is met, return `true` and
 /// pass the system output to [`Output`].
@@ -20,7 +21,10 @@ pub trait Runner {
     ///
     /// If this runner finishes, it must return `true`.
     /// If it returns `true`, an entity attached this runner will be removed.
-    fn run(&mut self, world: &mut World) -> bool;
+    fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool;
+
+    /// It called when [`Reactor`](crate::prelude::Reactor) processing is cancelled by [`CancellationToken::cancel`].
+    fn on_cancelled(&mut self, world: &mut World);
 }
 
 /// The boxed runner.
@@ -36,28 +40,38 @@ impl BoxedRunner {
     }
 }
 
-impl Runner for BoxedRunner{
+impl Runner for BoxedRunner {
     #[inline(always)]
-    fn run(&mut self, world: &mut World) -> bool {
-        self.0.run(world)
+    fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool {
+        if token.requested_cancel() {
+            true
+        } else {
+            self.0.run(world, token)
+        }
+    }
+
+    #[inline(always)]
+    fn on_cancelled(&mut self, world: &mut World) {
+        self.0.on_cancelled(world);
     }
 }
 
 #[repr(transparent)]
 #[derive(Resource)]
-struct BoxedRunners<L: Send + Sync>(Vec<BoxedRunner>, PhantomData<L>);
+struct BoxedRunners<L: Send + Sync>(Vec<(BoxedRunner, CancellationToken)>, PhantomData<L>);
 
 pub(crate) fn initialize_runner<Label>(
     world: &mut World,
     label: &Label,
-    runner: BoxedRunner,
+    token: CancellationToken,
+    runner: BoxedRunner
 )
     where Label: ScheduleLabel
 {
     if let Some(mut runners) = world.get_non_send_resource_mut::<BoxedRunners<Label>>() {
-        runners.0.push(runner);
+        runners.0.push((runner, token));
     } else {
-        world.insert_non_send_resource(BoxedRunners::<Label>(vec![runner], PhantomData));
+        world.insert_non_send_resource(BoxedRunners::<Label>(vec![(runner, token)], PhantomData));
         let Some(mut schedules) = world.get_resource_mut::<Schedules>() else {
             return;
         };
@@ -78,7 +92,14 @@ pub(crate) fn initialize_schedule(schedules: &mut Schedules, schedule_label: Int
 
 fn run_runners<L: Send + Sync + 'static>(world: &mut World) {
     if let Some(mut runners) = world.remove_non_send_resource::<BoxedRunners<L>>() {
-        runners.0.retain_mut(|r| !r.0.run(world));
+        runners.0.retain_mut(|(runner, token)| {
+            if token.requested_cancel() {
+                runner.on_cancelled(world);
+                false
+            } else {
+                !runner.run(world, token)
+            }
+        });
         world.insert_non_send_resource(runners);
     }
 }
@@ -88,10 +109,10 @@ pub(crate) mod macros {
         ($o1: expr, $o2: expr, $output: expr $(,)?) => {
             if let Some(out1) = $o1.take() {
                 if let Some(out2) = $o2.take() {
-                    $output.replace((out1, out2));
+                    $output.set((out1, out2));
                     true
                 } else {
-                    $o1.replace(out1);
+                    $o1.set(out1);
                     false
                 }
             } else {
@@ -102,10 +123,10 @@ pub(crate) mod macros {
         ($o1: expr, $o2: expr, $output: expr $(,$out: ident)*) => {
             if let Some(($($out,)*)) = $o1.take() {
                 if let Some(out2) = $o2.take() {
-                    $output.replace(($($out,)* out2));
+                    $output.set(($($out,)* out2));
                     true
                 } else {
-                    $o1.replace(($($out,)*));
+                    $o1.set(($($out,)*));
                     false
                 }
             } else {

--- a/src/runner/cancellation_token.rs
+++ b/src/runner/cancellation_token.rs
@@ -13,13 +13,15 @@ impl Clone for CancellationToken {
 }
 
 impl CancellationToken {
+    /// Requests to cancel a runner's action.
+    #[inline(always)]
+    pub fn cancel(&self) {
+        self.0.set(true);
+    }
+
+    /// Returns `true` if a runner's action has been requested to cancel.
     #[inline(always)]
     pub(crate) fn requested_cancel(&self) -> bool {
         self.0.get()
-    }
-
-    #[inline(always)]
-    pub(crate) fn cancel(&self) {
-        self.0.set(true);
     }
 }

--- a/src/runner/output.rs
+++ b/src/runner/output.rs
@@ -20,23 +20,29 @@ impl<O> Default for Output<O> {
 }
 
 impl<O> Output<O> {
+    /// Set the output value.
+    ///
+    /// If the output already exists, it is replaced.
     #[inline(always)]
-    pub(crate) fn replace(&self, o: O) {
+    pub fn set(&self, o: O) {
         self.0.borrow_mut().replace(o);
     }
 
+    /// Takes the value out of the [`Output`].
     #[inline(always)]
-    pub(crate) fn take(&self) -> Option<O> {
+    pub fn take(&self) -> Option<O> {
         self.0.borrow_mut().take()
     }
 
+    /// Returns true if output value is exists.
     #[inline(always)]
-    pub(crate) fn is_some(&self) -> bool {
+    pub fn is_some(&self) -> bool {
         self.0.borrow().is_some()
     }
 
+    /// Returns true if output value is not exists.
     #[inline(always)]
-    pub(crate) fn is_none(&self) -> bool {
+    pub fn is_none(&self) -> bool {
         self.0.borrow().is_none()
     }
 }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -47,8 +47,8 @@ impl<Label, In, Out> Selector<WorldPtr> for WorldSelector<Label, In, Out>
     fn select(&self, world: WorldPtr) -> Option<Self::Output> {
         let world: &mut World = world.as_mut();
         if let Some(action) = self.action.take() {
-            let runner = action.into_runner(self.token.clone(), self.output.clone());
-            initialize_runner(world, &self.label, runner);
+            let runner = action.into_runner(self.output.clone());
+            initialize_runner(world, &self.label, self.token.clone(), runner);
             None
         } else {
             self.output.take()

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,25 @@
+use std::future::Future;
+
+use bevy::app::App;
+use bevy::prelude::World;
+
+use crate::prelude::Reactor;
+use crate::task::ReactiveTask;
+
+pub trait SpawnReactor {
+    fn spawn_reactor<F>(&mut self, f: impl FnOnce(ReactiveTask) -> F + 'static)
+        where
+            F: Future;
+}
+
+impl SpawnReactor for World {
+    fn spawn_reactor<F>(&mut self, f: impl FnOnce(ReactiveTask) -> F + 'static) where F: Future {
+        self.spawn(Reactor::schedule(f));
+    }
+}
+
+impl SpawnReactor for App {
+    fn spawn_reactor<F>(&mut self, f: impl FnOnce(ReactiveTask) -> F + 'static) where F: Future {
+        self.world.spawn_reactor(f);
+    }
+}


### PR DESCRIPTION
## Update

Changed the accessiblity of the following methods from `pub(crate)` to `pub`.
Honestly, I just forgot to export these.

- `CancellationToken::cancel`
- `Output::set`
- `Output::take`
- `Output::is_none`
- `Output::is_some`

## Breaking Changes

### ActionSeed::new

Changed so that the Cancellation token is not passed when creating `ActionSeeed`.
Instead, a reference to that token is passed in the `Runner::run` argument.

```rust

// before
ActionSeed::new(|input, token, output|{
     ..
})

// after
ActionSeed::new(|input, output|{
     ..
})
```

### Runner::on_cancelled

Added `on_cancelled` method into `Runner`.
This is called when a cancellation isrequested, such as removing `Reactor` or calling `CancelletionToken::cancel` . 

## Bug Fix

Fixed an issue where the record were not unlocked properly when a nested `undo` or `redo` was cancelled.
