### PR TITLE
FIX(wait::any):  move actions into ActionSeed's Input

### DIFF
--- a/examples/undo_redo.rs
+++ b/examples/undo_redo.rs
@@ -129,7 +129,7 @@ fn spawn_move_reactor(
 ) {
     commands.spawn(Reactor::schedule(|task| async move {
         loop {
-            task.will(Update, wait::any(actions![
+            task.will(Update, wait::any().with(actions![
                     wait::input::any_just_released().with(vec![KeyCode::KeyA, KeyCode::ArrowLeft]),
                     wait::input::any_just_released().with(vec![KeyCode::KeyW, KeyCode::ArrowUp]),
                     wait::input::any_just_released().with(vec![KeyCode::KeyS, KeyCode::ArrowDown]),


### PR DESCRIPTION

Fixed ActionSeed to accept a collection of actions as input.

```rust

// before
wait::any(actions![
    once::run(||{})
])

// after
wait::any().with(actions![
    once::run(||{})
])
```

This fix allows us to pipe 

```rust
once::run(||{
    actions![once::run(||{})]
})
     .pipe(wait::any())
```