### PR TITLE
Breaking Change and FIX: Despawn Reactor once it's process is completed.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ harness = false
 
 [dependencies]
 bevy = { version = "0.13.2", default-features = false }
-flurx = { version = "0.1.4" }
+flurx = { version = "0.1.5" }
 futures-polling = "0.1.1"
 pollster = "0.3.0"
 

--- a/src/action/record.rs
+++ b/src/action/record.rs
@@ -160,26 +160,26 @@ pub(crate) fn unlock_record<Opr: Send + Sync + 'static>(world: &mut World) {
 }
 
 fn push_tracks<Act: Send + Sync + 'static>(track: impl Iterator<Item=Track<Act>>, world: &mut World, in_undo: bool) -> EditRecordResult {
-    let mut store = world.get_resource_or_insert_with::<Record<Act>>(Record::<Act>::default);
-    if in_undo && store.progressing {
+    let mut record = world.get_resource_or_insert_with::<Record<Act>>(Record::<Act>::default);
+    if in_undo && record.progressing {
         return Err(UndoRedoInProgress);
     }
     if in_undo {
-        store.redo.clear();
+        record.redo.clear();
     }
-    store.tracks.extend(track);
+    record.tracks.extend(track);
     Ok(())
 }
 
 fn push_track<Act: Send + Sync + 'static>(track: Track<Act>, world: &mut World, in_undo: bool) -> EditRecordResult {
-    let mut store = world.get_resource_or_insert_with::<Record<Act>>(Record::<Act>::default);
-    if in_undo && store.progressing {
+    let mut record = world.get_resource_or_insert_with::<Record<Act>>(Record::<Act>::default);
+    if in_undo && record.progressing {
         return Err(UndoRedoInProgress);
     }
     if in_undo {
-        store.redo.clear();
+        record.redo.clear();
     }
-    store.tracks.push(track);
+    record.tracks.push(track);
     Ok(())
 }
 

--- a/src/action/record/push.rs
+++ b/src/action/record/push.rs
@@ -43,13 +43,13 @@ pub fn push<Act>() -> ActionSeed<Track<Act>, EditRecordResult>
     ActionSeed::new(|track: Track<Act>, output| {
         PushRunner {
             output,
-            operation: Some(track),
+            track: Some(track),
         }
     })
 }
 
 struct PushRunner<Act> {
-    operation: Option<Track<Act>>,
+    track: Option<Track<Act>>,
     output: Output<EditRecordResult>,
 }
 
@@ -58,8 +58,8 @@ impl<Act> Runner for PushRunner<Act>
         Act: Send + Sync + 'static
 {
     fn run(&mut self, world: &mut World, _: &CancellationToken) -> bool {
-        if let Some(operation) = self.operation.take() {
-            if let Err(error) = push_track::<Act>(operation, world, true) {
+        if let Some(track) = self.track.take() {
+            if let Err(error) = push_track::<Act>(track, world, true) {
                 self.output.set(Err(error));
                 return true;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! This library provides a mechanism for more sequential description of delays, character movement,
 //! waiting for user input, and other state waits.
 //!
-//! `Reactor` can be used partially. 
+//! [`Reactor`] can be used partially. 
 //! This means there is no need to rewrite existing applications to use this library.
 //! And I recommend using it partially. 
-//! This is because the system that runs `Reactor` and the systems that are run by `Reactor` run on the main thread.
+//! This is because the system that runs [`Reactor`] and the systems that are run by [`Reactor`] run on the main thread.
 //! (Please check [`Switch`](crate::prelude::Switch) for multi thread operation.)
 
 
@@ -12,6 +12,7 @@
 
 use bevy::app::{App, Last, MainScheduleOrder, Plugin, PostStartup};
 use bevy::ecs::schedule::ScheduleLabel;
+use bevy::hierarchy::DespawnRecursiveExt;
 use bevy::prelude::{Entity, QueryState, Without, World};
 
 use crate::reactor::{Initialized, Reactor};
@@ -26,8 +27,8 @@ pub mod runner;
 pub mod prelude {
     pub use crate::{
         action::*,
-        action::omit::*,
         action::Map,
+        action::omit::*,
         action::pipe::Pipe,
         action::record::*,
         action::record::extension::*,
@@ -88,12 +89,33 @@ fn run_reactors(
     world: &mut World,
     reactors: &mut QueryState<(Entity, &mut Reactor, Option<&Initialized>)>,
 ) {
+    enum Status {
+        Finished,
+        Initialized,
+    }
+
     let world_ptr = WorldPtr::new(world);
+    let mut entities = Vec::with_capacity(reactors.iter(world).len());
     for (entity, mut reactor, initialized) in reactors.iter_mut(world) {
-        reactor.run_sync(world_ptr);
         if initialized.is_none() {
-            world_ptr.as_mut().entity_mut(entity).insert(Initialized);
-            reactor.run_sync(world_ptr);
+            if reactor.run_sync(world_ptr) || reactor.run_sync(world_ptr) {
+                entities.push((entity, Status::Finished));
+            } else {
+                entities.push((entity, Status::Initialized));
+            }
+        } else if reactor.run_sync(world_ptr) {
+            entities.push((entity, Status::Finished));
+        }
+    }
+    
+    for (entity, status) in entities {
+        match status {
+            Status::Finished => {
+                world.entity_mut(entity).despawn_recursive();
+            }
+            Status::Initialized => {
+                world.entity_mut(entity).insert(Initialized);
+            }
         }
     }
 }


### PR DESCRIPTION
Currently entities associated with `Reactor`s that have completed processing remain alive.
However, in many cases we won't want to do that, so I fixed it.

Also, when `Reactor` processing is completed, the related `Runner`s will be stopped, but `Runner::on_cancelled` will not be called.