### PR TITLE
[Fix, Add, Breaking]: Fixed arround cancellation

### DIFF
--- a/src/action/map.rs
+++ b/src/action/map.rs
@@ -90,11 +90,6 @@ impl<O1, O2, F> Runner for MapRunner<O1, O2, F>
             false
         }
     }
-
-    #[inline]
-    fn on_cancelled(&mut self, world: &mut World) {
-        self.r1.on_cancelled(world);
-    }
 }
 
 

--- a/src/action/omit.rs
+++ b/src/action/omit.rs
@@ -164,10 +164,6 @@ impl<O> Runner for OmitRunner<O> {
             false
         }
     }
-
-    fn on_cancelled(&mut self, world: &mut World) {
-        self.r1.on_cancelled(world);
-    }
 }
 
 

--- a/src/action/once.rs
+++ b/src/action/once.rs
@@ -126,7 +126,5 @@ impl<Sys, I, O> Runner for OnceRunner<Sys, I, O>
             false
         }
     }
-
-    fn on_cancelled(&mut self, _: &mut World) {}
 }
 

--- a/src/action/record/push.rs
+++ b/src/action/record/push.rs
@@ -67,8 +67,6 @@ impl<Act> Runner for PushRunner<Act>
         self.output.set(Ok(()));
         true
     }
-
-    fn on_cancelled(&mut self, _: &mut World) {}
 }
 
 

--- a/src/action/through.rs
+++ b/src/action/through.rs
@@ -130,11 +130,6 @@ impl<V> Runner for ThroughRunner<V>
             false
         }
     }
-
-    #[inline]
-    fn on_cancelled(&mut self, world: &mut World) {
-        self.inner.on_cancelled(world);
-    }
 }
 
 

--- a/src/action/tuple.rs
+++ b/src/action/tuple.rs
@@ -36,8 +36,4 @@ impl<O> Runner for TupleRunner<O> {
             false
         }
     }
-
-    fn on_cancelled(&mut self, world: &mut World) {
-        self.runner.on_cancelled(world);
-    }
 }

--- a/src/action/wait.rs
+++ b/src/action/wait.rs
@@ -135,9 +135,6 @@ impl<Sys, In, Out> Runner for WaitRunner<Sys, In, Out>
             false
         }
     }
-
-    fn on_cancelled(&mut self, _: &mut World) {
-    }
 }
 
 #[cfg(test)]

--- a/src/action/wait/all.rs
+++ b/src/action/wait/all.rs
@@ -54,12 +54,6 @@ impl Runner for AllRunner {
             false
         }
     }
-
-    fn on_cancelled(&mut self, world: &mut World) {
-        for runner in self.runners.iter_mut() {
-            runner.on_cancelled(world);
-        }
-    }
 }
 
 /// Wait until all tasks done.
@@ -196,11 +190,6 @@ pub mod private {
                     }else{
                         false
                     }
-                }
-
-                fn on_cancelled(&mut self, world: &mut bevy::ecs::world::World){
-                    self.r1.on_cancelled(world);
-                    self.r2.on_cancelled(world);
                 }
             }
         };

--- a/src/action/wait/any.rs
+++ b/src/action/wait/any.rs
@@ -62,12 +62,6 @@ impl Runner for AnyRunner {
         }
         false
     }
-
-    fn on_cancelled(&mut self, world: &mut World) {
-        for runner in self.runners.iter_mut() {
-            runner.on_cancelled(world);
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/action/wait/both.rs
+++ b/src/action/wait/both.rs
@@ -70,9 +70,4 @@ impl<O1, O2> Runner for BothRunner<O1, O2>
         }
         output_combine!(&self.o1, &self.o2, self.output)
     }
-
-    fn on_cancelled(&mut self, world: &mut World) {
-        self.r1.on_cancelled(world);
-        self.r2.on_cancelled(world);
-    }
 }

--- a/src/action/wait/either.rs
+++ b/src/action/wait/either.rs
@@ -105,11 +105,6 @@ impl<O1, O2> Runner for EitherRunner<O1, O2>
             false
         }
     }
-
-    fn on_cancelled(&mut self, world: &mut World) {
-        self.r1.on_cancelled(world);
-        self.r2.on_cancelled(world);
-    }
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ mod world_ptr;
 mod reactor;
 mod selector;
 
+/// Define utilities for testing. 
 #[cfg(test)]
 mod test_util;
 

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -67,8 +67,8 @@ impl Reactor {
     }
 
     #[inline(always)]
-    pub(crate) fn run_sync(&mut self, world: WorldPtr) -> bool{
-        if self.token.status().cancelled{
+    pub(crate) fn run_sync(&mut self, world: WorldPtr) -> bool {
+        if self.token.is_cancellation_requested() {
             return true;
         }
 
@@ -81,11 +81,8 @@ impl Reactor {
         {
             pollster::block_on(self.scheduler.run(world));
         }
-
-        let mut status = self.token.status();
-        status.reactor_finished = self.scheduler.not_exists_reactor();
-        self.token.set(status);
-        status.cancelled || status.reactor_finished
+        
+        self.token.is_cancellation_requested() || self.token.is_cancellation_requested()
     }
 }
 

--- a/src/runner/cancellation_token.rs
+++ b/src/runner/cancellation_token.rs
@@ -1,18 +1,52 @@
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::fmt::{Debug, Formatter};
 use std::rc::Rc;
 
-#[derive(Default, Debug, Copy, Clone)]
-pub(crate) struct ReactorStatus {
-    pub cancelled: bool,
-    pub reactor_finished: bool,
-}
+use bevy::prelude::World;
 
 /// Structure for canceling a [`Reactor`](crate::prelude::Reactor).
 ///
 /// This is passed as argument in [`Runner::run`](crate::prelude::Runner::run),
 /// and the [`Reactor`](crate::prelude::Reactor) can be cancelled by calling [`CancellationToken::cancel`]. 
 #[derive(Default, Debug)]
-pub struct CancellationToken(Rc<Cell<ReactorStatus>>);
+pub struct CancellationToken(Rc<ReactorStatus>);
+
+impl CancellationToken {
+    /// Register a function that will be called when [`CancellationToken`] is cancelled.
+    #[inline(always)]
+    pub fn register(&self, f: impl FnOnce(&mut World) + 'static) {
+        self.0.cancel_handles.borrow_mut().push(Box::new(f));
+    }
+
+    /// Requests to cancel a [`Reactor`](crate::prelude::Reactor).
+    #[inline(always)]
+    pub fn cancel(&self) {
+        self.0.is_cancellation_requested.set(true);
+    }
+
+    /// Returns `true` if cancellation has been requested for a [`Reactor`](crate::prelude::Reactor).
+    ///
+    /// Becomes `true` when [`CancellationToken::cancel`] is called or removed [`Reactor`](crate::prelude::Reactor)
+    /// before it processing is completed. 
+    #[must_use]
+    #[inline]
+    pub fn is_cancellation_requested(&self) -> bool {
+        self.0.is_cancellation_requested.get()
+    }
+
+    #[inline(always)]
+    pub(crate) fn call_cancel_handles(&self, world: &mut World) {
+        for handle in self.0.cancel_handles.take() {
+            (handle)(world);
+        }
+    }
+
+    #[must_use]
+    #[inline(always)]
+    pub(crate) fn finished_reactor(&self) -> bool {
+        self.0.reactor_finished.get()
+    }
+}
 
 impl Clone for CancellationToken {
     #[inline(always)]
@@ -21,24 +55,20 @@ impl Clone for CancellationToken {
     }
 }
 
-impl CancellationToken {
-    /// Requests to cancel a [`Reactor`](crate::prelude::Reactor).
-    #[inline(always)]
-    pub fn cancel(&self) {
-        let status = self.0.get();
-        self.0.set(ReactorStatus {
-            cancelled: true,
-            reactor_finished: status.reactor_finished,
-        });
-    }
+#[derive(Default)]
+pub(crate) struct ReactorStatus {
+    pub cancel_handles: RefCell<Vec<Box<dyn FnOnce(&mut World)>>>,
+    pub is_cancellation_requested: Cell<bool>,
+    pub reactor_finished: Cell<bool>,
+}
 
-    #[inline(always)]
-    pub(crate) fn set(&self, status: ReactorStatus) {
-        self.0.set(status);
-    }
-
-    #[inline(always)]
-    pub(crate) fn status(&self) -> ReactorStatus {
-        self.0.get()
+impl Debug for ReactorStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f
+            .debug_struct("ReactorStatus")
+            .field("is_cancellation_requested", &self.is_cancellation_requested.get())
+            .field("reactor_finished", &self.reactor_finished.get())
+            .finish()
     }
 }
+

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -23,3 +23,24 @@ impl SpawnReactor for App {
         self.world.spawn_reactor(f);
     }
 }
+
+pub mod test {
+    use bevy::prelude::World;
+
+    use crate::prelude::{ActionSeed, CancellationToken, Runner};
+
+    pub fn cancel() -> ActionSeed {
+        ActionSeed::new(|_, _| {
+            TestCancelRunner
+        })
+    }
+
+    struct TestCancelRunner;
+
+    impl Runner for TestCancelRunner {
+        fn run(&mut self, _: &mut World, token: &CancellationToken) -> bool {
+            token.cancel();
+            true
+        }
+    }
+}


### PR DESCRIPTION
`Runner::on_cancel` was added yesterday, but I identified a major performance problem, so I fixed it again. 

Specifically, there were two problems as below. 

1. We had to call the cancel process even for the runners that didn't need it.
2. If `on_cancell` is not implemented properly, the child runner's `on_cancell` is not called.

Instead, I added the `CancellationToken::register`.
This method registers a function that is called when the cancellation is requested.