### PR TITLE
[Feature, Breaking] add effect actions 

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[target.wasm32-unknown-unknown]
-runner = "wasm-server-runner"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 run-name: ${{ github.actor }} is testing
 on:
   push:
-  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -16,8 +15,10 @@ jobs:
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'
-      - name: Test
+      - name: Test all features
         run: cargo test --all-features --all
+      - name: Test
+        run: cargo test --all
   clippy:
     runs-on: ubuntu-latest
     steps:
@@ -30,5 +31,7 @@ jobs:
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
         if: runner.os == 'linux'
-      - name: Clippy
+      - name: Clippy all features
         run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Clippy
+        run: cargo clippy -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,28 +28,37 @@ name = "sequence"
 path = "benches/sequence.rs"
 harness = false
 
+[[example]]
+name = "effect"
+path = "examples/effect.rs"
+required-features = ["tokio"]
+
 [dependencies]
-bevy = { version = "0.13.2", default-features = false }
+bevy = { version = "0.13.2", default-features = false, features = ["multi-threaded"] }
 flurx = { version = "0.1.5" }
 futures-polling = "0.1.1"
 pollster = "0.3.0"
+tokio = { version = "1.37.0", optional = true, features = ["sync"] }
+futures-lite = "2.3.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-async-compat = "0.2.3"
+async-compat = { version = "0.2.3", optional = true }
 
 [dev-dependencies]
 bevy = { version = "0.13.2" }
 bevy_test_helper = { git = "https://github.com/not-elm/bevy_test_helper" }
-reqwest = "0.12.3"
+reqwest = "0.12.4"
 futures = "0.3.30"
 criterion = { version = "0.5.1", features = ["plotters", "html_reports"] }
 bevy_egui = "0.27.0"
+bevy_progress_bar = { version = "0.9.0" }
 
 [features]
 default = ["audio"]
 audio = ["bevy/bevy_audio", "bevy/bevy_asset"]
+tokio = ["dep:tokio", "dep:async-compat"]
 
-[workspace.lints.clippy]
+[lints.clippy]
 type_complexity = "allow"
 doc_markdown = "warn"
 manual_let_else = "warn"
@@ -58,5 +67,5 @@ redundant_else = "warn"
 match_same_arms = "warn"
 semicolon_if_nothing_returned = "warn"
 
-[workspace.lints.rust]
+[lints.rust]
 missing_docs = "warn"

--- a/benches/cmp_countup.rs
+++ b/benches/cmp_countup.rs
@@ -69,11 +69,11 @@ fn with_flurx(count: usize, c: &mut Criterion) {
     });
 }
 
-fn cmp_count_1000(c: &mut Criterion) {
-    const COUNT: usize = 1000;
+fn cmp_count_10000(c: &mut Criterion) {
+    const COUNT: usize = 10000;
     without_flurx(COUNT, c);
     with_flurx(COUNT, c);
 }
 
-criterion_group!(cmp_countup, cmp_count_1000);
+criterion_group!(cmp_countup, cmp_count_10000);
 criterion_main!(cmp_countup);

--- a/examples/effect.rs
+++ b/examples/effect.rs
@@ -1,0 +1,102 @@
+//! This example shows how to convert an asynchronous process such as HTTP communication into an action.
+
+
+use bevy::app::{App, Startup, Update};
+use bevy::DefaultPlugins;
+use bevy::prelude::{Camera2dBundle, Commands, default, Event, EventWriter, Local, Query, Res, Resource, Window, With};
+use bevy::window::PrimaryWindow;
+use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy_egui::egui::{Align2, Pos2};
+
+use bevy_flurx::prelude::*;
+
+
+#[derive(Event, Clone)]
+struct RequestGet {
+    url: String,
+}
+
+#[derive(Resource, Default)]
+struct ResponseInfo {
+    status: Option<reqwest::StatusCode>,
+    error_message: Option<String>,
+}
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            EguiPlugin,
+            FlurxPlugin
+        ))
+        .init_resource::<ResponseInfo>()
+        .add_event::<RequestGet>()
+        .add_systems(Startup, (
+            spawn_camera,
+            spawn_reactor,
+        ))
+        .add_systems(Update, show_ui)
+        .run();
+}
+
+fn spawn_camera(
+    mut commands: Commands
+) {
+    commands.spawn(Camera2dBundle::default());
+}
+
+fn spawn_reactor(
+    mut commands: Commands
+) {
+    commands.spawn(Reactor::schedule(|task| async move {
+        loop {
+            task.will(Update, {
+                wait::event::read::<RequestGet>()
+                    .pipe(effect::tokio::spawn(|RequestGet { url }| async move {
+                        match reqwest::get(url).await {
+                            Ok(response) => ResponseInfo {
+                                status: Some(response.status()),
+                                ..default()
+                            },
+                            Err(error) => ResponseInfo {
+                                error_message: Some(error.to_string()),
+                                ..default()
+                            }
+                        }
+                    }))
+                    .pipe(once::res::insert())
+            }).await;
+        }
+    }));
+}
+
+fn show_ui(
+    mut cx: EguiContexts,
+    mut ew: EventWriter<RequestGet>,
+    mut input_text: Local<String>,
+    window: Query<&Window, With<PrimaryWindow>>,
+    response: Res<ResponseInfo>,
+) {
+    egui::Window::new("bevy_flurx demo")
+        .pivot(Align2::CENTER_CENTER)
+        .default_pos(Pos2::new(window.single().width() / 2., window.single().height() / 2.))
+        .show(cx.ctx_mut(), |ui| {
+            ui.vertical(|ui| {
+                ui.add(egui::TextEdit::singleline(&mut *input_text).hint_text("url"));
+                if ui.button("submit").clicked() {
+                    ew.send(RequestGet {
+                        url: input_text.to_string()
+                    });
+                }
+                ui.allocate_space(egui::Vec2::new(1.0, 30.0));
+                ui.separator();
+                ui.vertical(|ui| {
+                    ui.label(format!("status code: {}", response.status.map(|s| s.to_string()).unwrap_or_default()));
+                    ui.label(format!("error message: {}", response.error_message.as_ref().map(|url| url.to_string()).unwrap_or_default()));
+                });
+            });
+        });
+}
+
+
+

--- a/src/action.rs
+++ b/src/action.rs
@@ -34,12 +34,13 @@
 //! - [`omit`]
 //! - [`map::Map`]
 //! - [`remake::Remake`]
+//! - [`effect`]
 
 pub use _tuple::tuple;
 pub use map::Map;
 pub use remake::Remake;
 
-use crate::prelude::{ActionSeed};
+use crate::prelude::ActionSeed;
 use crate::runner::{BoxedRunner, Output};
 
 pub mod once;
@@ -52,6 +53,7 @@ pub mod pipe;
 pub mod sequence;
 pub mod record;
 pub mod omit;
+pub mod effect;
 #[path = "action/tuple.rs"]
 mod _tuple;
 mod map;

--- a/src/action/delay.rs
+++ b/src/action/delay.rs
@@ -70,7 +70,6 @@ mod tests {
     use bevy::app::{AppExit, First, Startup};
     use bevy::ecs::event::ManualEventReader;
     use bevy::prelude::Commands;
-    use bevy::time::TimePlugin;
     use bevy_test_helper::event::DirectEvents;
 
     use crate::action::{delay, once};
@@ -82,7 +81,6 @@ mod tests {
     fn delay_1frame() {
         let mut app = test_app();
         app
-            .add_plugins(TimePlugin)
             .add_systems(Startup, |mut commands: Commands| {
                 commands.spawn(Reactor::schedule(|task| async move {
                     task.will(First, delay::frames().with(1)
@@ -102,7 +100,6 @@ mod tests {
     fn delay_2frames() {
         let mut app = test_app();
         app
-            .add_plugins(TimePlugin)
             .add_systems(Startup, |mut commands: Commands| {
                 commands.spawn(Reactor::schedule(|task| async move {
                     task.will(First, delay::frames().with(2)

--- a/src/action/effect/bevy_task.rs
+++ b/src/action/effect/bevy_task.rs
@@ -1,0 +1,15 @@
+//! Convert the bevy tasks into [`Action`](crate::prelude::Action).
+//!
+//! actions
+//!
+//! - [`effect::bevy_task::spawn`](crate::prelude::effect::bevy_task::spawn)
+//! - [`effect::bevy_task::spawn_detached`](crate::prelude::effect::bevy_task::spawn_detached)
+
+
+pub use _spawn::spawn;
+pub use _spawn_detached::spawn_detached;
+
+#[path = "bevy_task/spawn.rs"]
+mod _spawn;
+#[path = "bevy_task/spawn_detached.rs"]
+mod _spawn_detached;

--- a/src/action/effect/bevy_task/spawn.rs
+++ b/src/action/effect/bevy_task/spawn.rs
@@ -1,0 +1,129 @@
+use bevy::prelude::World;
+use crate::action::effect::AsyncFunctor;
+use crate::prelude::{ActionSeed, CancellationToken, Output, Runner};
+
+/// Spawns a future onto the bevy thread pool,
+/// and then wait until its completed.
+///
+/// ```no_run
+///
+/// use bevy::prelude::*;
+/// use bevy_flurx::prelude::*;
+///
+/// Reactor::schedule(|task| async move{
+///     task.will(Update, effect::bevy_task::spawn(async move{
+///
+///     })).await;
+/// });
+///
+/// Reactor::schedule(|task| async move{
+///     task.will(Update, {
+///         wait::output(|| Some(1))
+///             .pipe(effect::bevy_task::spawn(|num: usize| async move{
+///                 num + 1
+///             }))
+///             .pipe(once::run(|In(num): In<usize>|{
+///                 assert_eq!(num, 2);
+///             }))
+///     }).await;
+/// });
+/// ```
+pub fn spawn<I, Out, Functor, M>(f: Functor) -> ActionSeed<I, Out>
+    where
+        I: 'static,
+        Functor: AsyncFunctor<I, Out, M> + 'static,
+        Out: Send + 'static,
+        M: Send + 'static
+{
+    ActionSeed::new(|input, output| {
+        BevyTaskRunner {
+            output,
+            #[cfg(not(target_arch = "wasm32"))]
+            task: bevy::tasks::AsyncComputeTaskPool::get().spawn(f.functor(input)),
+            #[cfg(target_arch = "wasm32")]
+            task: Box::pin(f.functor(input))
+        }
+    })
+}
+
+struct BevyTaskRunner<Out> {
+    #[cfg(not(target_arch = "wasm32"))]
+    task: bevy::tasks::Task<Out>,
+    #[cfg(target_arch = "wasm32")]
+    task: std::pin::Pin<Box<dyn std::future::Future<Output=Out>>>,
+    output: Output<Out>,
+}
+
+impl<Out> Runner for BevyTaskRunner<Out>
+    where
+        Out: Send + 'static
+{
+    #[allow(clippy::async_yields_async)]
+    fn run(&mut self, _: &mut World, _: &CancellationToken) -> bool {
+        if let Some(out) = pollster::block_on(futures_lite::future::poll_once(&mut self.task)) {
+            self.output.set(out);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use bevy::app::{Startup, Update};
+    use bevy::core::TaskPoolPlugin;
+    use bevy::prelude::Commands;
+    use bevy_test_helper::resource::count::Count;
+    use bevy_test_helper::resource::DirectResourceControl;
+
+    use crate::action::{effect, once};
+    use crate::prelude::{Pipe, Reactor};
+    use crate::tests::test_app;
+
+    #[test]
+    fn test_simple_case() {
+        let mut app = test_app();
+        app.add_plugins(TaskPoolPlugin::default());
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                task.will(Update, {
+                    effect::bevy_task::spawn(async move {
+                        Count(1 + 1)
+                    })
+                        .pipe(once::res::insert())
+                }).await;
+            }));
+        });
+        app.update();
+        app.assert_resource_eq(Count(2));
+    }
+}
+
+#[cfg(all(test, feature = "tokio"))]
+mod test_tokio {
+    use bevy::app::{Startup, Update};
+    use bevy::core::TaskPoolPlugin;
+    use bevy::prelude::Commands;
+
+    use crate::action::effect;
+    use crate::prelude::Reactor;
+    use crate::tests::test_app;
+
+    #[test]
+    fn not_failed_with_tokio_task() {
+        let mut app = test_app();
+        app.add_plugins(TaskPoolPlugin::default());
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                task.will(Update, {
+                    effect::bevy_task::spawn(async move {
+                        tokio::time::sleep(std::time::Duration::new(1, 0)).await;
+                    })
+                }).await;
+            }));
+        });
+        app.update();
+    }
+}

--- a/src/action/effect/bevy_task/spawn_detached.rs
+++ b/src/action/effect/bevy_task/spawn_detached.rs
@@ -1,0 +1,127 @@
+use std::marker::PhantomData;
+use std::sync::{Arc, Mutex};
+
+use bevy::prelude::World;
+use bevy::tasks::AsyncComputeTaskPool;
+
+use crate::action::effect::AsyncFunctor;
+use crate::prelude::{ActionSeed, CancellationToken, Output};
+use crate::runner::Runner;
+
+
+/// Spawns a future onto the bevy thread pool, 
+/// and then wait until its completed.
+///
+/// Unlike [`effect::bevy_task::spawn`](crate::prelude::effect::bevy_task::spawn_detached),
+/// a spawned task is detached and continues to run in the background.
+/// 
+/// Note that tasks created from this function will continue to run even if [`Reactor`](crate::prelude::Reactor) is canceled.
+/// 
+/// ```no_run
+///
+/// use bevy::prelude::*;
+/// use bevy_flurx::prelude::*;
+///
+/// Reactor::schedule(|task| async move{
+///     task.will(Update, effect::bevy_task::spawn_detached(async move{
+///
+///     })).await;
+/// });
+///
+/// Reactor::schedule(|task| async move{
+///     task.will(Update, {
+///         wait::output(|| Some(1))
+///             .pipe(effect::bevy_task::spawn_detached(|num: usize| async move{
+///                 num + 1
+///             }))
+///             .pipe(once::run(|In(num): In<usize>|{
+///                 assert_eq!(num, 2);
+///             }))
+///     }).await;
+/// });
+/// ```
+pub fn spawn_detached<I, Out, Functor, M>(functor: Functor) -> ActionSeed<I, Out>
+    where
+        I: Send + 'static,
+        Functor: AsyncFunctor<I, Out, M> + Send + 'static,
+        Out: Send + 'static,
+        M: Send + 'static
+{
+    ActionSeed::new(|input, output| {
+        BevyDetachedTaskRunner {
+            output,
+            arc_output: Arc::new(Mutex::new(None)),
+            args: Some((input, functor)),
+            _m: PhantomData::<M>,
+        }
+    })
+}
+
+struct BevyDetachedTaskRunner<I, O, Functor, M> {
+    arc_output: Arc<Mutex<Option<O>>>,
+    args: Option<(I, Functor)>,
+    output: Output<O>,
+    _m: PhantomData<M>,
+}
+
+impl<I, O, Functor, M> Runner for BevyDetachedTaskRunner<I, O, Functor, M>
+    where
+        I: Send + 'static,
+        O: Send + 'static,
+        Functor: AsyncFunctor<I, O, M> + Send + 'static,
+        M: Send + 'static
+{
+    fn run(&mut self, _: &mut World, _: &CancellationToken) -> bool {
+        if let Some((input, f)) = self.args.take() {
+            let o = self.arc_output.clone();
+            AsyncComputeTaskPool::get()
+                .spawn(async move {
+                    let out = f.functor(input).await;
+                    o.lock().unwrap().replace(out);
+                })
+                .detach();
+        }
+
+        if let Some(out) = self.arc_output.lock().unwrap().take() {
+            self.output.set(out);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use bevy::app::Startup;
+    use bevy::core::TaskPoolPlugin;
+    use bevy::prelude::{Commands, Update};
+    use bevy_test_helper::resource::count::Count;
+    use bevy_test_helper::resource::DirectResourceControl;
+    use crate::action::{effect, once};
+    use crate::prelude::Pipe;
+
+    use crate::reactor::Reactor;
+    use crate::tests::test_app;
+
+    #[test]
+    fn test_simple_spawn_detached() {
+        let mut app = test_app();
+        app.add_plugins(TaskPoolPlugin::default());
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                task.will(Update, {
+                    effect::bevy_task::spawn_detached(async move{
+                        Count(1 + 1)
+                    })
+                        .pipe(once::res::insert())
+                }).await;
+            }));
+        });
+        app.update();
+        std::thread::sleep(Duration::from_millis(20));
+        app.update();
+        app.assert_resource_eq(Count(2));
+    }
+}

--- a/src/action/effect/thread.rs
+++ b/src/action/effect/thread.rs
@@ -1,0 +1,118 @@
+//! Convert the thread operations into [`Action`](crate::prelude::Action).
+//! 
+//! actions
+//! 
+//! - [`effect::thread::spawn`](crate::prelude::effect::thread::spawn)
+
+use std::sync::{Arc, Mutex};
+
+use bevy::prelude::World;
+
+use crate::prelude::{ActionSeed, CancellationToken};
+use crate::runner::{Output, Runner};
+
+
+/// Spawns a new os thread, and then wait for its output.
+///
+/// The thread is started when [`Runner`] is executed for the first time.
+///
+/// Note that thead created from this function will continue to run even if [`Reactor`](crate::prelude::Reactor) is canceled.
+/// 
+/// # Examples
+/// 
+/// ```no_run
+/// 
+/// use bevy::prelude::*;
+/// use bevy_flurx::prelude::*;
+///
+/// Reactor::schedule(|task| async move{
+///     task.will(Update, {
+///         once::run(||{
+///             2
+///         })
+///             .pipe(effect::thread::spawn(|num: usize|{
+///                 num + 3
+///             }))
+///             .pipe(once::run(|In(num): In<usize>|{
+///                 assert_eq!(num, 5);
+///             }))
+///     }).await;
+/// });
+/// ```
+pub fn spawn<I, O>(f: impl FnOnce(I) -> O + Send + 'static) -> ActionSeed<I, O>
+    where
+        I: Send + 'static,
+        O: Send + 'static
+{
+    ActionSeed::new(|input, output: Output<O>| {
+        ThreadRunner {
+            arc_output: Arc::new(Mutex::new(None)),
+            args: Some((input, f)),
+            output,
+            handle: None,
+        }
+    })
+}
+
+struct ThreadRunner<I, O, F> {
+    arc_output: Arc<Mutex<Option<O>>>,
+    args: Option<(I, F)>,
+    output: Output<O>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl<I, O, F> Runner for ThreadRunner<I, O, F>
+    where
+        I: Send + 'static,
+        O: Send + 'static,
+        F: FnOnce(I) -> O + Send + 'static
+{
+    fn run(&mut self, _: &mut World, _: &CancellationToken) -> bool {
+        if let Some((input, f)) = self.args.take() {
+            let arc_out = self.arc_output.clone();
+            self.handle.replace(std::thread::spawn(move || {
+                arc_out.lock().unwrap().replace(f(input));
+            }));
+        }
+
+        if let Some(out) = self.arc_output.lock().unwrap().take() {
+            self.output.set(out);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use bevy::prelude::{Commands, In, ResMut, Startup, Update};
+    use bevy_test_helper::resource::count::Count;
+    use bevy_test_helper::resource::DirectResourceControl;
+
+    use crate::action::{effect, once};
+    use crate::prelude::{Pipe, Reactor};
+    use crate::tests::test_app;
+
+    #[test]
+    fn thread_calc_2() {
+        let mut app = test_app();
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                task.will(Update, {
+                    effect::thread::spawn(|_| {
+                        1 + 1
+                    })
+                        .pipe(once::run(|In(num): In<usize>, mut count: ResMut<Count>| {
+                            count.0 = num;
+                        }))
+                }).await;
+            }));
+        });
+        app.update();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        app.update();
+        app.assert_resource_eq(Count(2));
+    }
+}

--- a/src/action/effect/tokio.rs
+++ b/src/action/effect/tokio.rs
@@ -1,0 +1,214 @@
+//! Convert the tokio tasks into [`Action`](crate::prelude::Action).
+//!
+//! action
+//!
+//! - [`effect::tokio::spawn`](crate::prelude::effect::tokio::spawn)
+
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use async_compat::CompatExt;
+use bevy::prelude::World;
+use tokio::task::JoinHandle;
+
+use crate::action::effect::AsyncFunctor;
+use crate::prelude::{ActionSeed, CancellationToken};
+use crate::runner::{Output, Runner};
+
+/// Spawns a new tokio task, and then wait its output.
+///
+/// The task is started when [`Runner`] is executed for the first time.
+///
+/// # Example
+///
+/// ```no_run
+///
+/// use bevy::prelude::*;
+/// use bevy_flurx::prelude::*;
+///
+/// Reactor::schedule(|task| async move{
+///     task.will(Update, {
+///         once::run(|| 2)
+///             .pipe(effect::tokio::spawn(|num: usize| async move{
+///                 num + 3
+///             }))
+///             .pipe(once::run(|In(num): In<usize>|{
+///                 assert_eq!(num, 5);
+///             }))
+///     }).await;   
+/// });
+/// ```
+pub fn spawn<I, Out, Functor, M>(f: Functor) -> ActionSeed<I, Out>
+    where
+        I: Send + 'static,
+        M: Send + 'static,
+        Out: Send + 'static,
+        Functor: AsyncFunctor<I, Out, M> + Send + 'static,
+{
+    ActionSeed::new(|input: I, output: Output<Out>| {
+        TokioRunner {
+            arc_output: Arc::new(tokio::sync::Mutex::new(None)),
+            args: Some((input, f)),
+            output,
+            handle: None,
+            _m: PhantomData,
+        }
+    })
+}
+
+struct TokioRunner<I, Out, Functor, M>
+
+{
+    args: Option<(I, Functor)>,
+    arc_output: Arc<tokio::sync::Mutex<Option<Out>>>,
+    output: Output<Out>,
+    handle: Option<JoinHandle<()>>,
+    _m: PhantomData<M>,
+}
+
+impl<I, Out, Functor, M> Runner for TokioRunner<I, Out, Functor, M>
+    where
+        I: Send + 'static,
+        Functor: AsyncFunctor<I, Out, M> + Send + 'static,
+        M: Send + 'static,
+        Out: Send + 'static
+{
+    #[allow(clippy::async_yields_async)]
+    fn run(&mut self, _: &mut World, _: &CancellationToken) -> bool {
+        if let Some((input, functor)) = self.args.take() {
+            let arc_output = self.arc_output.clone();
+            self.handle.replace(pollster::block_on(async move {
+                tokio::spawn(async move {
+                    arc_output.lock().await.replace(functor.functor(input).await);
+                })
+            }.compat()));
+        }
+
+        if let Some(out) = self.arc_output.blocking_lock().take() {
+            self.output.set(out);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<I, Out, Functor, M> Drop for TokioRunner<I, Out, Functor, M> {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use bevy::app::Startup;
+    use bevy::prelude::{Commands, In, ResMut, Update};
+    use bevy_test_helper::event::DirectEvents;
+    use bevy_test_helper::resource::count::Count;
+    use bevy_test_helper::resource::DirectResourceControl;
+
+    use crate::action::{delay, effect, once, wait};
+    use crate::actions;
+    use crate::prelude::{Pipe, Reactor, Then};
+    use crate::tests::{exit_reader, test_app};
+
+    #[test]
+    fn tokio_task_with_input() {
+        let mut app = test_app();
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                task.will(Update, effect::tokio::spawn(|_| async move { 1 + 1 })
+                    .pipe(once::run(|In(num): In<usize>, mut count: ResMut<Count>| {
+                        count.0 = num;
+                    })),
+                ).await;
+            }));
+        });
+        app.update();
+        std::thread::sleep(Duration::from_millis(10));
+        app.update();
+        app.assert_resource_eq(Count(2));
+    }
+
+    #[test]
+    fn tokio_task_without_input() {
+        let mut app = test_app();
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                task.will(Update, effect::tokio::spawn(async move { 1 + 1 })
+                    .pipe(once::run(|In(num): In<usize>, mut count: ResMut<Count>| {
+                        count.0 = num;
+                    })),
+                ).await;
+            }));
+        });
+        app.update();
+        std::thread::sleep(Duration::from_millis(10));
+        app.update();
+        app.assert_resource_eq(Count(2));
+    }
+
+    #[test]
+    fn cancel_tokio_task() {
+        let mut app = test_app();
+        static TASK_FINISHED: AtomicBool = AtomicBool::new(false);
+
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                task.will(Update, {
+                    wait::either(
+                        once::run(|| {}),
+                        effect::tokio::spawn(|_| async move {
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            TASK_FINISHED.store(true, Ordering::Relaxed);
+                        })
+                            .then(once::event::app_exit()),
+                    )
+                        // keep running while the test is running
+                        .then(delay::time().with(Duration::from_secs(1000)))
+                }).await;
+            }));
+        });
+        let mut er = exit_reader();
+        app.update();
+        std::thread::sleep(Duration::from_millis(200));
+        app.assert_event_not_comes(&mut er);
+        assert!(!TASK_FINISHED.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn cancel_tokio_task_wait_any() {
+        let mut app = test_app();
+        static TASK_FINISHED: AtomicBool = AtomicBool::new(false);
+
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                task.will(Update, {
+                    wait::any().with(actions![
+                        once::run(|| {}),
+                        once::run(|| {}),
+                        effect::tokio::spawn(|_| async move {
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            TASK_FINISHED.store(true, Ordering::Relaxed);
+                        })
+                            .then(once::event::app_exit())
+                    ])
+                        // keep running while the test is running
+                        .then(delay::time().with(Duration::from_secs(1000)))
+                }).await;
+            }));
+        });
+        let mut er = exit_reader();
+        app.update();
+        std::thread::sleep(Duration::from_millis(200));
+        app.assert_event_not_comes(&mut er);
+        assert!(!TASK_FINISHED.load(Ordering::Relaxed));
+    }
+}

--- a/src/action/record/redo.rs
+++ b/src/action/record/redo.rs
@@ -1,5 +1,5 @@
 //! Define the actions related to `redo` operations.
-//! To perform these the actions, you must call the one of the [`record::undo`](crate::prelude::undo) actions beforehand.
+//! To perform these the actions, you must call the one of the [`record::undo`](crate::prelude::record::undo) actions beforehand.
 //!
 //!
 //! actions

--- a/src/action/seed.rs
+++ b/src/action/seed.rs
@@ -14,6 +14,8 @@ use crate::runner::{BoxedRunner, Output, Runner};
 ///
 /// [`Action`]: crate::prelude::Action
 /// [`Pipe::pipe`]: crate::prelude::Pipe::pipe
+/// 
+///
 pub struct ActionSeed<I = (), O = ()>(Box<dyn FnOnce(I, Output<O>) -> BoxedRunner>, PhantomData<I>);
 
 impl<I, O> ActionSeed<I, O>

--- a/src/action/wait/any.rs
+++ b/src/action/wait/any.rs
@@ -54,13 +54,20 @@ struct AnyRunner {
 
 impl Runner for AnyRunner {
     fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool {
+        let mut finished = None;
         for (i, runner) in self.runners.iter_mut().enumerate() {
             if runner.run(world, token) {
-                self.output.set(i);
-                return true;
+                finished.replace(i);
+                break;
             }
         }
-        false
+        if let Some(finished_index) = finished {
+            self.runners.clear();
+            self.output.set(finished_index);
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/src/action/wait/either.rs
+++ b/src/action/wait/either.rs
@@ -1,8 +1,8 @@
 use bevy::prelude::World;
-use crate::action::Action;
 
-use crate::prelude::ActionSeed;
-use crate::runner::{BoxedRunner, CancellationToken, Output, Runner};
+use crate::action::Action;
+use crate::prelude::{ActionSeed, DisposableRunner};
+use crate::runner::{CancellationToken, Output, Runner};
 
 /// This enum represents the result of [`wait::either`](crate::prelude::wait::either).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -68,19 +68,19 @@ pub fn either<LI, LO, RI, RO, >(
         let o1 = Output::default();
         let o2 = Output::default();
         EitherRunner {
-            r1: ls.with(input.0).into_runner(o1.clone()),
-            r2: rs.with(input.1).into_runner(o2.clone()),
+            r1: DisposableRunner::new(ls.with(input.0).into_runner(o1.clone())),
+            r2: DisposableRunner::new(rs.with(input.1).into_runner(o2.clone())),
             o1,
             o2,
-            output
+            output,
         }
     })
         .with((li, ri))
 }
 
 struct EitherRunner<O1, O2> {
-    r1: BoxedRunner,
-    r2: BoxedRunner,
+    r1: DisposableRunner,
+    r2: DisposableRunner,
     o1: Output<O1>,
     o2: Output<O2>,
     output: Output<Either<O1, O2>>,

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -5,7 +5,6 @@ use std::future::Future;
 use bevy::prelude::{Commands, EntityWorldMut, World};
 
 use crate::prelude::Reactor;
-use crate::reactor::Initialized;
 use crate::task::ReactiveTask;
 use crate::world_ptr::WorldPtr;
 
@@ -28,10 +27,8 @@ impl<'w, Fun, Fut> ScheduleReactor<'w, Fun, Fut, EntityWorldMut<'w>> for World
     fn spawn_initialized_reactor(&'w mut self, f: Fun) -> EntityWorldMut<'w> {
         let mut reactor = Reactor::schedule(f);
         reactor.run_sync(WorldPtr::new(self));
-        self.spawn((
-            Initialized,
-            reactor
-        ))
+        reactor.initialized = true;
+        self.spawn(reactor)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod runner;
 pub mod prelude {
     pub use crate::{
         action::*,
+        action::effect::AsyncFunctor,
         action::Map,
         action::omit::*,
         action::pipe::Pipe,
@@ -125,7 +126,8 @@ mod tests {
     use bevy::ecs::event::ManualEventReader;
     use bevy::ecs::system::RunSystemOnce;
     use bevy::input::InputPlugin;
-    use bevy::prelude::{Event, EventReader, ResMut, Resource};
+    use bevy::prelude::{Event, EventReader, FrameCountPlugin, ResMut, Resource};
+    use bevy::time::TimePlugin;
     use bevy_test_helper::BevyTestHelperPlugin;
     use bevy_test_helper::resource::count::Count;
 
@@ -161,7 +163,9 @@ mod tests {
         app.add_plugins((
             BevyTestHelperPlugin,
             FlurxPlugin,
-            InputPlugin
+            InputPlugin,
+            TimePlugin,
+            FrameCountPlugin
         ));
         app.add_record_events::<NumAct>();
         app.add_record_events::<TestAct>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,9 @@
 use bevy::app::{App, Last, MainScheduleOrder, Plugin, PostStartup};
 use bevy::ecs::schedule::ScheduleLabel;
 use bevy::hierarchy::DespawnRecursiveExt;
-use bevy::prelude::{Entity, QueryState, Without, World};
+use bevy::prelude::{Entity, QueryState, World};
 
-use crate::reactor::{Initialized, Reactor};
+use crate::reactor::Reactor;
 use crate::world_ptr::WorldPtr;
 
 pub mod extension;
@@ -35,8 +35,8 @@ pub mod prelude {
             Record,
             Redo,
             RedoAction,
-            Track,
             Rollback,
+            Track,
             Undo,
             UndoRedoInProgress,
         },
@@ -86,46 +86,34 @@ struct RunReactor;
 
 fn initialize_reactors(
     world: &mut World,
-    reactors: &mut QueryState<(Entity, &mut Reactor), Without<Initialized>>,
+    reactors: &mut QueryState<&mut Reactor>,
 ) {
     let world_ptr = WorldPtr::new(world);
-    for (entity, mut reactor) in reactors.iter_mut(world) {
-        world_ptr.as_mut().entity_mut(entity).insert(Initialized);
+    for mut reactor in reactors.iter_mut(world) {
+        if reactor.initialized {
+            continue;
+        }
+        reactor.initialized = true;
         reactor.run_sync(world_ptr);
     }
 }
 
 fn run_reactors(
     world: &mut World,
-    reactors: &mut QueryState<(Entity, &mut Reactor, Option<&Initialized>)>,
+    reactors: &mut QueryState<(Entity, &mut Reactor)>,
 ) {
-    enum Status {
-        Finished,
-        Initialized,
-    }
-
     let world_ptr = WorldPtr::new(world);
-    let mut entities = Vec::with_capacity(reactors.iter(world).len());
-    for (entity, mut reactor, initialized) in reactors.iter_mut(world) {
-        if initialized.is_none() {
+    for (entity, mut reactor) in reactors.iter_mut(world) {
+        if !reactor.initialized {
             if reactor.run_sync(world_ptr) || reactor.run_sync(world_ptr) {
-                entities.push((entity, Status::Finished));
+                world_ptr.as_mut().entity_mut(entity).despawn_recursive();
+                // entities.push((entity, Status::Finished));
             } else {
-                entities.push((entity, Status::Initialized));
+                reactor.initialized = true;
             }
         } else if reactor.run_sync(world_ptr) {
-            entities.push((entity, Status::Finished));
-        }
-    }
-
-    for (entity, status) in entities {
-        match status {
-            Status::Finished => {
-                world.entity_mut(entity).despawn_recursive();
-            }
-            Status::Initialized => {
-                world.entity_mut(entity).insert(Initialized);
-            }
+            world_ptr.as_mut().entity_mut(entity).despawn_recursive();
+            // entities.push((entity, Status::Finished));
         }
     }
 }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -70,12 +70,12 @@ impl Reactor {
             return true;
         }
 
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(all(not(target_arch = "wasm32"), feature = "tokio"))]
         {
             use async_compat::CompatExt;
             pollster::block_on(self.scheduler.run(world).compat());
         }
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(any(target_arch = "wasm32", not(feature = "tokio")))]
         {
             pollster::block_on(self.scheduler.run(world));
         }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -6,10 +6,6 @@ use crate::runner::CancellationToken;
 use crate::task::ReactiveTask;
 use crate::world_ptr::WorldPtr;
 
-#[derive(Component, Debug, Copy, Clone)]
-pub(crate) struct Initialized;
-
-
 /// [`Reactor`] represents the asynchronous processing flow.
 ///
 /// This structure is created by [`Reactor::schedule`] or [`ScheduleReactor`](crate::prelude::ScheduleReactor).
@@ -21,6 +17,7 @@ pub(crate) struct Initialized;
 #[derive(Component)]
 pub struct Reactor {
     pub(crate) scheduler: flurx::Scheduler<'static, 'static, WorldPtr>,
+    pub(crate) initialized: bool,
     token: CancellationToken,
 }
 
@@ -63,6 +60,7 @@ impl Reactor {
         Self {
             scheduler,
             token,
+            initialized: false,
         }
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -81,9 +81,7 @@ pub(crate) fn initialize_schedule(schedules: &mut Schedules, schedule_label: Int
 fn run_runners<L: Send + Sync + 'static>(world: &mut World) {
     if let Some(mut runners) = world.remove_non_send_resource::<BoxedRunners<L>>() {
         runners.0.retain_mut(|(runner, token)| {
-            if token.finished_reactor() {
-                false
-            } else if token.is_cancellation_requested() {
+            if token.is_cancellation_requested() {
                 token.call_cancel_handles(world);
                 false
             } else {


### PR DESCRIPTION
## Feature

Added a mechanism to convert processes with side effects that are executed outside the bevy world, such as threads and asynchronous tasks, into reference transparent actions.

```rust

fn spawn_reactor(
    mut commands: Commands
) {
    commands.spawn(Reactor::schedule(|task| async move {
        task.will(Update, effect::bevy_task::spawn(async move {
            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
        })).await;

        task.will(Update, {
            once::run(|| {
                300
            })
                .pipe(effect::bevy_task::spawn(|millis: u64| async move {
                    tokio::time::sleep(std::time::Duration::from_millis(millis)).await;
                }))
        }).await;

        // not support on wasm32
        task.will(Update, effect::thread::spawn(|_| {
            std::thread::sleep(std::time::Duration::from_millis(300));
        })).await;

        // not support on wasm32 and require [`tokio`] feature flag
        task.will(Update, effect::tokio::spawn(async move {
            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
        })).await;
    }));
}
```

## Breaking Change

Added `tokio` feature flag.
Along with this, I have changed the default process of adapting to the future of `tokio` and `features` to an option by default.

By adding the tokio flag, it will work as before.
