### PR TITLE
[Improve]:  destroy the internal runner after the BoxedRunner is completed

### DIFF
--- a/src/action/wait/either.rs
+++ b/src/action/wait/either.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::World;
 
 use crate::action::Action;
-use crate::prelude::{ActionSeed, DisposableRunner};
+use crate::prelude::{ActionSeed, BoxedRunner};
 use crate::runner::{CancellationToken, Output, Runner};
 
 /// This enum represents the result of [`wait::either`](crate::prelude::wait::either).
@@ -68,8 +68,8 @@ pub fn either<LI, LO, RI, RO, >(
         let o1 = Output::default();
         let o2 = Output::default();
         EitherRunner {
-            r1: DisposableRunner::new(ls.with(input.0).into_runner(o1.clone())),
-            r2: DisposableRunner::new(rs.with(input.1).into_runner(o2.clone())),
+            r1: ls.with(input.0).into_runner(o1.clone()),
+            r2: rs.with(input.1).into_runner(o2.clone()),
             o1,
             o2,
             output,
@@ -79,8 +79,8 @@ pub fn either<LI, LO, RI, RO, >(
 }
 
 struct EitherRunner<O1, O2> {
-    r1: DisposableRunner,
-    r2: DisposableRunner,
+    r1: BoxedRunner,
+    r2: BoxedRunner,
     o1: Output<O1>,
     o2: Output<O2>,
     output: Output<Either<O1, O2>>,


### PR DESCRIPTION
The definition of BoxedRunner has been changed as follows to destroy the inner inner runner and free up memory after the runner operation is complete.

```rust

BoxedRunner(Option<Box<dyn Runner>>)
```