### PR TITLE
[Fix, Breaking]: switch condition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ name = "effect"
 path = "examples/effect.rs"
 required-features = ["tokio"]
 
+[[example]]
+name = "switch_just_change"
+path = "examples/bug_check/switch_just_change.rs"
+
 [dependencies]
 bevy = { version = "0.13.2", default-features = false, features = ["multi-threaded"] }
 flurx = { version = "0.1.5" }

--- a/examples/bug_check/README.md
+++ b/examples/bug_check/README.md
@@ -1,0 +1,1 @@
+This module checks cases that cannot be tested by unit tests.

--- a/examples/bug_check/switch_just_change.rs
+++ b/examples/bug_check/switch_just_change.rs
@@ -1,0 +1,46 @@
+//! Testing that the system runs properly when the switch is switched
+
+use bevy::prelude::*;
+
+use bevy_flurx::prelude::*;
+
+struct S;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            FlurxPlugin
+        ))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (
+            console_switch_just_on::<1>.run_if(switch_just_turned_on::<S>),
+            console_switch_just_on::<2>.run_if(switch_just_turned_on::<S>),
+            console_switch_just_off::<1>.run_if(switch_just_turned_off::<S>),
+            console_switch_just_off::<2>.run_if(switch_just_turned_off::<S>)
+        ))
+        .run();
+}
+
+fn setup(
+    mut commands: Commands
+) {
+    commands.spawn(Reactor::schedule(|task| async move {
+        loop {
+            task.will(Update, wait::input::just_pressed().with(KeyCode::KeyT)
+                .then(once::switch::on::<S>())
+                .then(delay::frames().with(1))
+                .then(wait::input::just_pressed().with(KeyCode::KeyT))
+                .then(once::switch::off::<S>()),
+            ).await;
+        }
+    }));
+}
+
+fn console_switch_just_on<const NUM: u8>() {
+    println!("[{NUM}] switch just turned on!");
+}
+
+fn console_switch_just_off<const NUM: u8>() {
+    println!("[{NUM}] switch just turned off!");
+}

--- a/examples/cut_in.rs
+++ b/examples/cut_in.rs
@@ -36,10 +36,10 @@ fn main() {
             setup,
         ))
         .add_systems(Update, (
-            cut_in::<CutInBackground, 200>.run_if(switch_turned_on::<CutInBackground>),
-            cut_in_ferris.run_if(switch_turned_on::<HandsomeFerris>),
-            move_left_down::<25>.run_if(switch_turned_on::<MoveSlowly>),
-            move_left_down::<10000>.run_if(switch_turned_on::<MoveFast>)
+            cut_in::<CutInBackground, 200>.run_if(switch_is_on::<CutInBackground>),
+            cut_in_ferris.run_if(switch_is_on::<HandsomeFerris>),
+            move_left_down::<25>.run_if(switch_is_on::<MoveSlowly>),
+            move_left_down::<10000>.run_if(switch_is_on::<MoveFast>)
         ))
         .run();
 }

--- a/src/action/wait/switch.rs
+++ b/src/action/wait/switch.rs
@@ -29,7 +29,7 @@ pub fn on<M>() -> ActionSeed
     where M: Send + Sync + 'static
 {
     wait::until(|switch: Option<Res<Switch<M>>>| {
-        switch.is_some_and(|s| s.turned_on())
+        switch.is_some_and(|s| s.is_on())
     })
 }
 
@@ -55,6 +55,6 @@ pub fn off<M>() -> ActionSeed
     where M: Send + Sync + 'static
 {
     wait::until(|switch: Option<Res<Switch<M>>>| {
-        switch.is_some_and(|s| s.turned_off())
+        switch.is_some_and(|s| s.is_off())
     })
 }


### PR DESCRIPTION
## Fix

- fixed a bug where the execution run condition `switch_just_*` was not  working correctly.

## Breaking Change

- rename `switch_turned_on` to ``switch_is_on`
- rename `switch_turned_off` to `switch_is_on`
- delete `Switch::just_turned_on`
- delete `Switch::just_turned_off`