### PR TITLE
[Improve] add feature flags: (effect, record)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,11 @@ bevy_egui = "0.27.0"
 bevy_progress_bar = { version = "0.9.0" }
 
 [features]
-default = ["audio"]
+default = ["audio", "record", "effect"]
 audio = ["bevy/bevy_audio", "bevy/bevy_asset"]
 tokio = ["dep:tokio", "dep:async-compat"]
+record = []
+effect = []
 
 [lints.clippy]
 type_complexity = "allow"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 This library provides a mechanism for more sequential description of delays, character movement,
 waiting for user input, and other state waits.
 
-As an example, here is an example of a cut-in effect that involves waiting for user input, a slight delay, and a sprite to move.
+As an example, here is an example of a cut-in effect that involves waiting for user input, a slight delay, and a sprite
+to move.
 
 ![cut_in](examples/cut_in.gif)
 
@@ -54,6 +55,36 @@ Please see [here](https://github.com/not-elm/bevy_flurx/blob/main/CHANGELOG.md).
 | 0.3.0         | 0.13.0 |
 | 0.3.1         | 0.13.1 |
 | 0.3.2 ~ 0.5.0 | 0.13.2 | 
+
+## Feature flags
+
+| flag name | short description              | default |
+|-----------|--------------------------------|---------|
+| audio     | audio actions                  | true    |
+| record    | undo/redo actions and events   | true    | 
+| effect    | thread/async side effects      | true    |
+| tokio     | async-compat and async actions | false   | 
+
+### audio
+
+Provides the actions that perform simple audio playback and waiting using bevy's default audio functionality.  
+
+- once::audio
+- wait::audio
+
+### record
+
+Provides `Record` to manage operation history.
+
+![undo_redo](examples/undo_redo.gif)
+
+### effect
+
+Allows to convert the operations with side effects such as asynchronous runtime or thread into the referential-transparent actions.
+
+### tokio
+
+You will be able to write processes that depend on tokio's runtime in the reactor.
 
 ## License
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -51,9 +51,11 @@ pub mod seed;
 pub mod through;
 pub mod pipe;
 pub mod sequence;
-pub mod record;
 pub mod omit;
+#[cfg(feature = "effect")]
 pub mod effect;
+#[cfg(feature = "record")]
+pub mod record;
 #[path = "action/tuple.rs"]
 mod _tuple;
 mod map;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,21 +27,9 @@ pub mod runner;
 pub mod prelude {
     pub use crate::{
         action::*,
-        action::effect::AsyncFunctor,
         action::Map,
         action::omit::*,
         action::pipe::Pipe,
-        action::record::{
-            EditRecordResult,
-            Record,
-            Redo,
-            RedoAction,
-            Rollback,
-            Track,
-            Undo,
-            UndoRedoInProgress,
-        },
-        action::record::extension::*,
         action::Remake,
         action::seed::ActionSeed,
         action::sequence::Then,
@@ -53,6 +41,20 @@ pub mod prelude {
         reactor::Reactor,
         runner::*,
         task::ReactiveTask,
+    };
+    #[cfg(feature = "effect")]
+    pub use crate::action::effect::AsyncFunctor;
+    #[cfg(feature = "record")]
+    pub use crate::action::record::{
+        EditRecordResult,
+        extension::{RecordExtension, RequestRedo, RequestUndo},
+        Record,
+        Redo,
+        RedoAction,
+        Rollback,
+        Track,
+        Undo,
+        UndoRedoInProgress,
     };
 }
 


### PR DESCRIPTION
It carved out some of the existing functionality to `feature flags`.

---

This allows you to reduce the binary size.

```
cargo build --release --no-default-features

before: libbevy_flurx.rlib 1034KB
after : libbevy_flurx.rlib 727KB
```