### PR TITLE
[Update]: flurx version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_flurx"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["elm"]
 categories = ["asynchronous", "game-development"]
@@ -39,7 +39,7 @@ path = "examples/bug_check/switch_just_change.rs"
 
 [dependencies]
 bevy = { version = "0.13.2", default-features = false, features = ["multi-threaded"] }
-flurx = { version = "0.1.5" }
+flurx = { version = "0.1.6" }
 futures-polling = "0.1.1"
 pollster = "0.3.0"
 tokio = { version = "1.37.0", optional = true, features = ["sync"] }

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Please see [here](https://github.com/not-elm/bevy_flurx/blob/main/CHANGELOG.md).
 
 ## Compatible Bevy versions
 
-| bevy_flurx    | bevy   |
-|---------------|--------|
-| 0.3.0         | 0.13.0 |
-| 0.3.1         | 0.13.1 |
-| 0.3.2 ~ 0.5.0 | 0.13.2 | 
+| bevy_flurx     | bevy   |
+|----------------|--------|
+| 0.3.0          | 0.13.0 |
+| 0.3.1          | 0.13.1 |
+| 0.3.2 ~ latest | 0.13.2 | 
 
 ## Feature flags
 


### PR DESCRIPTION
[The core library](https://github.com/not-elm/flurx) has been updated.

`Reducer` and default selectors are now disabled by default, so you can expect a slight reduction in binary size.