### PR TITLE
[Refactor, Fix] add cancellation id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,13 +110,11 @@ fn run_reactors(
         if !reactor.initialized {
             if reactor.run_sync(world_ptr) || reactor.run_sync(world_ptr) {
                 world_ptr.as_mut().entity_mut(entity).despawn_recursive();
-                // entities.push((entity, Status::Finished));
             } else {
                 reactor.initialized = true;
             }
         } else if reactor.run_sync(world_ptr) {
             world_ptr.as_mut().entity_mut(entity).despawn_recursive();
-            // entities.push((entity, Status::Finished));
         }
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -6,7 +6,7 @@ use bevy::ecs::schedule::ScheduleLabel;
 use bevy::prelude::{Schedule, Schedules, World};
 use bevy::utils::intern::Interned;
 
-pub use cancellation_token::CancellationToken;
+pub use cancellation_token::{CancellationId, CancellationToken};
 pub use output::Output;
 
 mod output;

--- a/src/runner/cancellation_token.rs
+++ b/src/runner/cancellation_token.rs
@@ -1,25 +1,43 @@
 use std::cell::{Cell, RefCell};
 use std::fmt::{Debug, Formatter};
 use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use bevy::prelude::World;
+use bevy::utils::HashMap;
+
+
+/// The cancellation handler id assigned by [`CancellationToken`].
+///
+/// For unregister the handler, call [`CancellationToken::unregister`] with this id.
+#[repr(transparent)]
+#[derive(Default, Debug, Eq, PartialEq, Hash)]
+pub struct CancellationId(u64);
+
 
 /// Structure for canceling a [`Reactor`](crate::prelude::Reactor).
 ///
 /// This is passed as argument in [`Runner::run`](crate::prelude::Runner::run),
 /// and the [`Reactor`](crate::prelude::Reactor) can be cancelled by calling [`CancellationToken::cancel`]. 
+#[repr(transparent)]
 #[derive(Default, Debug)]
 pub struct CancellationToken(Rc<ReactorStatus>);
 
 impl CancellationToken {
     /// Register a function that will be called when [`CancellationToken`] is cancelled.
-    #[inline(always)]
-    pub fn register(&self, f: impl FnOnce(&mut World) + 'static) {
-        self.0.cancel_handles.borrow_mut().push(Box::new(f));
+    #[inline]
+    pub fn register(&self, f: impl FnOnce(&mut World) + 'static) -> CancellationId {
+        self.0.register(f)
+    }
+
+    /// Unregister a cancellation handler related to [`CancellationId`].
+    #[inline]
+    pub fn unregister(&self, id: &CancellationId){
+        self.0.cancel_handles.borrow_mut().remove(id);
     }
 
     /// Requests to cancel a [`Reactor`](crate::prelude::Reactor).
-    #[inline(always)]
+    #[inline]
     pub fn cancel(&self) {
         self.0.is_cancellation_requested.set(true);
     }
@@ -29,14 +47,14 @@ impl CancellationToken {
     /// Becomes `true` when [`CancellationToken::cancel`] is called or removed [`Reactor`](crate::prelude::Reactor)
     /// before it processing is completed. 
     #[must_use]
-    #[inline]
+    #[inline(always)]
     pub fn is_cancellation_requested(&self) -> bool {
         self.0.is_cancellation_requested.get()
     }
 
-    #[inline(always)]
+    #[inline]
     pub(crate) fn call_cancel_handles(&self, world: &mut World) {
-        for handle in self.0.cancel_handles.take() {
+        for (_, handle) in self.0.cancel_handles.take() {
             (handle)(world);
         }
     }
@@ -57,15 +75,25 @@ impl Clone for CancellationToken {
 
 #[derive(Default)]
 pub(crate) struct ReactorStatus {
-    pub cancel_handles: RefCell<Vec<Box<dyn FnOnce(&mut World)>>>,
+    pub cancellation_id: AtomicU64,
+    pub cancel_handles: RefCell<HashMap<CancellationId, Box<dyn FnOnce(&mut World)>>>,
     pub is_cancellation_requested: Cell<bool>,
     pub reactor_finished: Cell<bool>,
+}
+
+impl ReactorStatus{
+    fn register(&self, f: impl FnOnce(&mut World) + 'static) -> CancellationId{
+        let id = self.cancellation_id.fetch_add(1, Ordering::Relaxed);
+        self.cancel_handles.borrow_mut().insert(CancellationId(id), Box::new(f));
+        CancellationId(id)
+    }
 }
 
 impl Debug for ReactorStatus {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f
             .debug_struct("ReactorStatus")
+            .field("cancellation_id", &self.cancellation_id.load(Ordering::Relaxed))
             .field("is_cancellation_requested", &self.is_cancellation_requested.get())
             .field("reactor_finished", &self.reactor_finished.get())
             .finish()


### PR DESCRIPTION
## Fix add cancellation id
Fixed a bug where if you registered a cancellation handler to a runner, and then called cancel method while the next runner was running, the handler of the first runner would be called.

## Refactor

- Remove unnecessary field in `OnceRunner`