### PR TITLE
Support for bevy0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ name = "switch_just_change"
 path = "examples/bug_check/switch_just_change.rs"
 
 [dependencies]
-bevy = { version = "0.15.0", default-features = false, features = ["multi_threaded"] }
+bevy = { version = "0.15.0", default-features = false }
 flurx = { version = "0.1.6" }
 futures-polling = "0.1.1"
 pollster = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,37 +9,35 @@ keywords = ["game", "gamedev", "bevy", "async"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/not-elm/bevy_flurx"
+autoexamples = false
 
-[workspace]
-exclude = ["benches"]
+# [[bench]]
+# name = "cmp_countup"
+# path = "benches/cmp_countup.rs"
+# harness = false
 
-[[bench]]
-name = "cmp_countup"
-path = "benches/cmp_countup.rs"
-harness = false
+# [[bench]]
+# name = "cmp_repeat_countup"
+# path = "benches/cmp_repeat_countup.rs"
+# harness = false
 
-[[bench]]
-name = "cmp_repeat_countup"
-path = "benches/cmp_repeat_countup.rs"
-harness = false
+# [[bench]]
+# name = "sequence"
+# path = "benches/sequence.rs"
+# harness = false
 
-[[bench]]
-name = "sequence"
-path = "benches/sequence.rs"
-harness = false
+# [[example]]
+# name = "effect"
+# path = "examples/effect.rs"
+# required-features = ["tokio"]
 
-[[example]]
-name = "effect"
-path = "examples/effect.rs"
-required-features = ["tokio"]
-
-[[example]]
-name = "switch_just_change"
-path = "examples/bug_check/switch_just_change.rs"
+# [[example]]
+# name = "switch_just_change"
+# path = "examples/bug_check/switch_just_change.rs"
 
 
 [dependencies]
-bevy = { version = "0.14.1", default-features = false, features = ["multi_threaded"] }
+bevy = { version = "0.15.0-rc.1", default-features = false, features = ["multi_threaded"] }
 flurx = { version = "0.1.6" }
 futures-polling = "0.1.1"
 pollster = "0.3.0"
@@ -50,12 +48,12 @@ futures-lite = "2.3.0"
 async-compat = { version = "0.2.3", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.14.1" }
-bevy_test_helper = { git = "https://github.com/not-elm/bevy_test_helper" }
+bevy = { version = "0.15.0-rc.1" }
+bevy_test_helper = { git = "https://github.com/not-elm/bevy_test_helper", branch = "v0.15.0" }
 reqwest = "0.12.5"
 futures = "0.3.30"
 criterion = { version = "0.5.1", features = ["plotters", "html_reports"] }
-bevy_egui = "0.28.0"
+bevy_egui = "0.30.0"
 bevy_progress_bar = { version = "0.9.0" }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,52 +9,49 @@ keywords = ["game", "gamedev", "bevy", "async"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/not-elm/bevy_flurx"
-autoexamples = false
 
-# [[bench]]
-# name = "cmp_countup"
-# path = "benches/cmp_countup.rs"
-# harness = false
+ [[bench]]
+ name = "cmp_countup"
+ path = "benches/cmp_countup.rs"
+ harness = false
 
-# [[bench]]
-# name = "cmp_repeat_countup"
-# path = "benches/cmp_repeat_countup.rs"
-# harness = false
+ [[bench]]
+ name = "cmp_repeat_countup"
+ path = "benches/cmp_repeat_countup.rs"
+ harness = false
 
-# [[bench]]
-# name = "sequence"
-# path = "benches/sequence.rs"
-# harness = false
+ [[bench]]
+ name = "sequence"
+ path = "benches/sequence.rs"
+ harness = false
 
-# [[example]]
-# name = "effect"
-# path = "examples/effect.rs"
-# required-features = ["tokio"]
+ [[example]]
+ name = "effect"
+ path = "examples/effect.rs"
+ required-features = ["tokio"]
 
-# [[example]]
-# name = "switch_just_change"
-# path = "examples/bug_check/switch_just_change.rs"
-
+[[example]]
+name = "switch_just_change"
+path = "examples/bug_check/switch_just_change.rs"
 
 [dependencies]
-bevy = { version = "0.15.0-rc.1", default-features = false, features = ["multi_threaded"] }
+bevy = { version = "0.15.0", default-features = false, features = ["multi_threaded"] }
 flurx = { version = "0.1.6" }
 futures-polling = "0.1.1"
-pollster = "0.3.0"
-tokio = { version = "1.37.0", optional = true, features = ["sync"] }
-futures-lite = "2.3.0"
+pollster = "0.4.0"
+tokio = { version = "1.42.0", optional = true, features = ["sync"] }
+futures-lite = "2.5.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-compat = { version = "0.2.3", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15.0-rc.1" }
+bevy = { version = "0.15.0" }
 bevy_test_helper = { git = "https://github.com/not-elm/bevy_test_helper", branch = "v0.15.0" }
-reqwest = "0.12.5"
-futures = "0.3.30"
+reqwest = "0.12.9"
+futures = "0.3.31"
 criterion = { version = "0.5.1", features = ["plotters", "html_reports"] }
-bevy_egui = "0.30.0"
-bevy_progress_bar = { version = "0.9.0" }
+bevy_egui = "0.31.1"
 
 [features]
 default = ["audio", "record", "effect"]

--- a/examples/cancel.rs
+++ b/examples/cancel.rs
@@ -4,8 +4,8 @@
 //!
 //! [`Reactor`]: bevy_flurx::prelude::Reactor
 
-use bevy::DefaultPlugins;
 use bevy::prelude::*;
+use bevy::DefaultPlugins;
 
 use bevy_flurx::prelude::*;
 
@@ -14,64 +14,42 @@ struct RotateBox;
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins,
-            FlurxPlugin
-        ))
-        .add_systems(Startup, (
-            setup_camera_and_box,
-            spawn_reactor
-        ))
+        .add_plugins((DefaultPlugins, FlurxPlugin))
+        .add_systems(Startup, (setup_camera_and_box, spawn_reactor))
         .add_systems(Update, cancel)
         .run();
 }
 
-fn setup_camera_and_box(
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-) {
+fn setup_camera_and_box(mut commands: Commands, mut materials: ResMut<Assets<StandardMaterial>>) {
     commands.spawn((
-        PbrBundle {
-            mesh: meshes.add(Cuboid::new(1., 1., 1.)),
-            material: materials.add(StandardMaterial {
-                base_color: Color::WHITE,
-                ..default()
-            }),
+        MeshMaterial3d(materials.add(StandardMaterial {
+            base_color: Color::WHITE,
             ..default()
-        },
-        RotateBox
+        })),
+        Transform::default(),
+        RotateBox,
     ));
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             shadows_enabled: true,
             intensity: 10_000_000.,
             range: 100.0,
             ..default()
         },
-        transform: Transform::from_xyz(8.0, 16.0, 8.0),
-        ..default()
-    });
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0., 0., 6.),
-        ..default()
-    });
+        Transform::from_xyz(8.0, 16.0, 8.0),
+    ));
+    commands.spawn((Camera3d::default(), Transform::from_xyz(0., 0., 6.)));
 }
 
-fn spawn_reactor(
-    mut commands: Commands
-) {
+fn spawn_reactor(mut commands: Commands) {
     commands.spawn(Reactor::schedule(|task| async move {
         task.will(Update, wait::until(rotate_shape)).await;
     }));
 }
 
-fn rotate_shape(
-    mut shape: Query<&mut Transform, With<RotateBox>>,
-    time: Res<Time>,
-) -> bool {
+fn rotate_shape(mut shape: Query<&mut Transform, With<RotateBox>>, time: Res<Time>) -> bool {
     for mut t in shape.iter_mut() {
-        t.rotate_y(time.delta_seconds());
+        t.rotate_y(time.delta_secs());
     }
     false
 }

--- a/examples/cut_in.rs
+++ b/examples/cut_in.rs
@@ -26,31 +26,26 @@ struct MoveFast;
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins,
-            FlurxPlugin
-        ))
-        .add_systems(Startup, (
-            spawn_reactor,
-            spawn_ferris,
-            setup,
-        ))
-        .add_systems(Update, (
-            cut_in::<CutInBackground, 200>.run_if(switch_is_on::<CutInBackground>),
-            cut_in_ferris.run_if(switch_is_on::<HandsomeFerris>),
-            move_left_down::<25>.run_if(switch_is_on::<MoveSlowly>),
-            move_left_down::<10000>.run_if(switch_is_on::<MoveFast>)
-        ))
+        .add_plugins((DefaultPlugins, FlurxPlugin))
+        .add_systems(Startup, (spawn_reactor, spawn_ferris, setup))
+        .add_systems(
+            Update,
+            (
+                cut_in::<CutInBackground, 200>.run_if(switch_is_on::<CutInBackground>),
+                cut_in_ferris.run_if(switch_is_on::<HandsomeFerris>),
+                move_left_down::<25>.run_if(switch_is_on::<MoveSlowly>),
+                move_left_down::<10000>.run_if(switch_is_on::<MoveFast>),
+            ),
+        )
         .run();
 }
 
-fn spawn_reactor(
-    mut commands: Commands
-) {
+fn spawn_reactor(mut commands: Commands) {
     commands.spawn(Reactor::schedule(|task| async move {
         info!("please press [`R`] key!");
         task.will(Update, {
-            wait::input::just_pressed().with(KeyCode::KeyR)
+            wait::input::just_pressed()
+                .with(KeyCode::KeyR)
                 .then(once::switch::on::<CutInBackground>())
                 .then(delay::time().with(Duration::from_millis(100)))
                 .then(once::switch::on::<HandsomeFerris>())
@@ -65,30 +60,27 @@ fn spawn_reactor(
                 .then(delay::time().with(Duration::from_millis(300)))
                 .then(once::event::app_exit_success())
         })
-            .await;
+        .await;
     }));
 }
 
-fn setup(
-    mut commands: Commands,
-    window: Query<&Window, With<PrimaryWindow>>,
-) {
+fn setup(mut commands: Commands, window: Query<&Window, With<PrimaryWindow>>) {
     let wh = &window.single().resolution;
     let angle = (wh.height() / 2.).atan2(wh.width() / 2.);
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                custom_size: Some(Vec2::new(wh.width() * 2., 300.)),
-                color: Color::srgb(0.8, 0.6, 0.1),
-                ..default()
-            },
-            transform: Transform::from_rotation(Quat::from_rotation_z(angle))
-                .with_translation(Vec3::new(wh.width() * 2., wh.height(), 0.)),
+        Sprite {
+            custom_size: Some(Vec2::new(wh.width() * 2., 300.)),
+            color: Color::srgb(0.8, 0.6, 0.1),
             ..default()
         },
-        CutInBackground
+        Transform::from_rotation(Quat::from_rotation_z(angle)).with_translation(Vec3::new(
+            wh.width() * 2.,
+            wh.height(),
+            0.,
+        )),
+        CutInBackground,
     ));
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 }
 
 fn spawn_ferris(
@@ -100,19 +92,20 @@ fn spawn_ferris(
     const WIDTH: f32 = HEIGHT * 1.5;
 
     let wh = &window.single().resolution;
-    let pos = Vec3::new(wh.width() / 2. + WIDTH / 2., wh.height() / 2. + HEIGHT / 2., 1.);
+    let pos = Vec3::new(
+        wh.width() / 2. + WIDTH / 2.,
+        wh.height() / 2. + HEIGHT / 2.,
+        1.,
+    );
     commands.spawn((
-        SpriteBundle {
-            sprite: Sprite {
-                custom_size: Some(Vec2::new(WIDTH, HEIGHT)),
-                ..default()
-            },
-            texture: asset_server.load("rustacean-flat-gesture.png"),
-            transform: Transform::from_translation(pos),
+        Sprite {
+            custom_size: Some(Vec2::new(WIDTH, HEIGHT)),
+            image: asset_server.load("rustacean-flat-gesture.png"),
             ..default()
         },
+        Transform::from_translation(pos),
         StartPos(pos),
-        HandsomeFerris
+        HandsomeFerris,
     ));
 }
 
@@ -121,25 +114,32 @@ fn cut_in<M, const S: u64>(
     mut switch: ResMut<Switch<M>>,
     mut tick: Local<f32>,
     time: Res<Time>,
-) where M: Component {
+) where
+    M: Component,
+{
     let mut t = target.single_mut();
     let end = Duration::from_millis(S).as_secs_f32();
-    *tick = end.min(*tick + time.delta_seconds());
-    t.translation = t.translation.lerp(Vec2::ZERO.extend(t.translation.z), *tick / end);
+    *tick = end.min(*tick + time.delta_secs());
+    t.translation = t
+        .translation
+        .lerp(Vec2::ZERO.extend(t.translation.z), *tick / end);
     if (*tick - end).abs() < 0.1 {
         switch.off();
     }
 }
 
 fn cut_in_ferris(
-    mut ferris: Query<(&mut Transform, &StartPos), (With<HandsomeFerris>, Without<CutInBackground>)>,
+    mut ferris: Query<
+        (&mut Transform, &StartPos),
+        (With<HandsomeFerris>, Without<CutInBackground>),
+    >,
     mut switch: ResMut<Switch<HandsomeFerris>>,
     mut tick: Local<f32>,
     time: Res<Time>,
 ) {
     let (mut t, StartPos(start)) = ferris.single_mut();
     let end = Duration::from_millis(300).as_secs_f32();
-    *tick = end.min(*tick + time.delta_seconds());
+    *tick = end.min(*tick + time.delta_secs());
     let d = *tick / end;
     let d = (d * PI / 2.).sin();
 
@@ -154,6 +154,6 @@ fn move_left_down<const SPEED: u16>(
     bg: Query<&Transform, (With<CutInBackground>, Without<HandsomeFerris>)>,
     time: Res<Time>,
 ) {
-    let d = time.delta_seconds() * SPEED as f32;
+    let d = time.delta_secs() * SPEED as f32;
     ferris.single_mut().translation -= bg.single().rotation * Vec3::new(d, 0., 0.);
 }

--- a/examples/effect.rs
+++ b/examples/effect.rs
@@ -1,7 +1,9 @@
 //! This example shows how to convert an asynchronous process such as HTTP communication into an action.
 
 use bevy::app::{App, Startup, Update};
-use bevy::prelude::{default, Camera2d, Camera2dBundle, Commands, Event, EventWriter, Local, Query, Res, Resource, Window, With};
+use bevy::prelude::{
+    default, Camera2d, Commands, Event, EventWriter, Local, Query, Res, Resource, Window, With,
+};
 use bevy::window::PrimaryWindow;
 use bevy::DefaultPlugins;
 use bevy_egui::egui::{Align2, Pos2};

--- a/examples/undo_redo.rs
+++ b/examples/undo_redo.rs
@@ -11,14 +11,17 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use bevy::app::{App, Startup, Update};
-use bevy::DefaultPlugins;
 use bevy::math::{Vec2, Vec3};
-use bevy::prelude::{Camera2dBundle, Color, Commands, Component, EventWriter, In, KeyCode, LinearRgba, Local, Query, Res, Sprite, Transform, With};
+use bevy::prelude::{
+    Camera2dBundle, Color, Commands, Component, EventWriter, In, KeyCode, LinearRgba, Local, Query,
+    Res, Sprite, Transform, With,
+};
 use bevy::sprite::SpriteBundle;
 use bevy::time::Time;
 use bevy::utils::default;
-use bevy_egui::{egui, EguiContexts, EguiPlugin};
+use bevy::DefaultPlugins;
 use bevy_egui::egui::{Color32, RichText};
+use bevy_egui::{egui, EguiContexts, EguiPlugin};
 
 use bevy_flurx::actions;
 use bevy_flurx::prelude::*;
@@ -33,32 +36,27 @@ type StartAndEndPos = (Vec3, Vec3);
 
 fn main() {
     App::new()
-        .add_plugins((
-            DefaultPlugins,
-            EguiPlugin,
-            FlurxPlugin
-        ))
+        .add_plugins((DefaultPlugins, EguiPlugin, FlurxPlugin))
         .init_resource::<Record<MoveAct>>()
         .add_record_events::<MoveAct>()
-        .add_systems(Startup, (
-            spawn_camera,
-            spawn_mr_shape,
-            spawn_undo_redo_reactor,
-            spawn_move_reactor,
-        ))
+        .add_systems(
+            Startup,
+            (
+                spawn_camera,
+                spawn_mr_shape,
+                spawn_undo_redo_reactor,
+                spawn_move_reactor,
+            ),
+        )
         .add_systems(Update, show_record)
         .run();
 }
 
-fn spawn_camera(
-    mut commands: Commands
-) {
+fn spawn_camera(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
 }
 
-fn spawn_mr_shape(
-    mut commands: Commands
-) {
+fn spawn_mr_shape(mut commands: Commands) {
     commands.spawn((
         MrShape,
         SpriteBundle {
@@ -68,19 +66,22 @@ fn spawn_mr_shape(
                 ..default()
             },
             ..default()
-        }
+        },
     ));
 }
 
-fn spawn_undo_redo_reactor(
-    mut commands: Commands
-) {
+fn spawn_undo_redo_reactor(mut commands: Commands) {
     commands.spawn(Reactor::schedule(|task| async move {
         loop {
-            let either = task.will(Update, wait::either(
-                wait::input::just_pressed().with(KeyCode::KeyZ),
-                wait::input::just_pressed().with(KeyCode::KeyX),
-            )).await;
+            let either = task
+                .will(
+                    Update,
+                    wait::either(
+                        wait::input::just_pressed().with(KeyCode::KeyZ),
+                        wait::input::just_pressed().with(KeyCode::KeyX),
+                    ),
+                )
+                .await;
             if either.is_left() {
                 let _ = task.will(Update, record::undo::once::<MoveAct>()).await;
             } else {
@@ -99,99 +100,110 @@ fn show_record(
     egui::SidePanel::right("record")
         .min_width(200.)
         .show(context.ctx_mut(), |ui| {
-            ui
-                .vertical(|ui| {
-                    let size = egui::Vec2::new(ui.available_width(), 30.);
-                    for act in record.acts() {
-                        let button = egui::Button::new(RichText::new(&act.1).color(Color32::BLACK))
-                            .fill(Color32::GREEN)
-                            .min_size(size);
-                        if ui.add(button).clicked() {
-                            undo.send(RequestUndo::To(act.clone()));
-                        }
+            ui.vertical(|ui| {
+                let size = egui::Vec2::new(ui.available_width(), 30.);
+                for act in record.acts() {
+                    let button = egui::Button::new(RichText::new(&act.1).color(Color32::BLACK))
+                        .fill(Color32::GREEN)
+                        .min_size(size);
+                    if ui.add(button).clicked() {
+                        undo.send(RequestUndo::To(act.clone()));
                     }
-                    for act in record.redo_acts().rev() {
-                        let button = egui::Button::new(RichText::new(&act.1).color(Color32::WHITE))
-                            .fill(Color32::RED)
-                            .min_size(size);
-                        if ui.add(button).clicked() {
-                            redo.send(RequestRedo::To(act.clone()));
-                        }
+                }
+                for act in record.redo_acts().rev() {
+                    let button = egui::Button::new(RichText::new(&act.1).color(Color32::WHITE))
+                        .fill(Color32::RED)
+                        .min_size(size);
+                    if ui.add(button).clicked() {
+                        redo.send(RequestRedo::To(act.clone()));
                     }
-                });
+                }
+            });
         });
 }
 
-fn spawn_move_reactor(
-    mut commands: Commands
-) {
+fn spawn_move_reactor(mut commands: Commands) {
     commands.spawn(Reactor::schedule(|task| async move {
         loop {
-            task.will(Update, wait::any().with(actions![
-                    wait::input::any_just_released().with(vec![KeyCode::KeyA, KeyCode::ArrowLeft]),
-                    wait::input::any_just_released().with(vec![KeyCode::KeyW, KeyCode::ArrowUp]),
-                    wait::input::any_just_released().with(vec![KeyCode::KeyS, KeyCode::ArrowDown]),
-                    wait::input::any_just_released().with(vec![KeyCode::KeyD, KeyCode::ArrowRight]),
-                ])
-                .pipe(return_start_and_end_pos())
-                .pipe(move_action::<1000>())
-                .pipe(push_move_track()),
+            task.will(
+                Update,
+                wait::any()
+                    .with(actions![
+                        wait::input::any_just_released()
+                            .with(vec![KeyCode::KeyA, KeyCode::ArrowLeft]),
+                        wait::input::any_just_released()
+                            .with(vec![KeyCode::KeyW, KeyCode::ArrowUp]),
+                        wait::input::any_just_released()
+                            .with(vec![KeyCode::KeyS, KeyCode::ArrowDown]),
+                        wait::input::any_just_released()
+                            .with(vec![KeyCode::KeyD, KeyCode::ArrowRight]),
+                    ])
+                    .pipe(return_start_and_end_pos())
+                    .pipe(move_action::<1000>())
+                    .pipe(push_move_track()),
             )
-                .await;
+            .await;
         }
     }));
 }
 
 fn return_start_and_end_pos() -> ActionSeed<usize, StartAndEndPos> {
-    once::run(|In(key_index): In<usize>,
-               m: Query<&Transform, With<MrShape>>| {
-        let start = m.single().translation;
-        let output = |end: Vec3| {
-            (start, start + end * 100.)
-        };
-        match key_index {
-            0 => output(Vec3::NEG_X),
-            1 => output(Vec3::Y),
-            2 => output(Vec3::NEG_Y),
-            _ => output(Vec3::X),
-        }
-    })
+    once::run(
+        |In(key_index): In<usize>, m: Query<&Transform, With<MrShape>>| {
+            let start = m.single().translation;
+            let output = |end: Vec3| (start, start + end * 100.);
+            match key_index {
+                0 => output(Vec3::NEG_X),
+                1 => output(Vec3::Y),
+                2 => output(Vec3::NEG_Y),
+                _ => output(Vec3::X),
+            }
+        },
+    )
 }
 
 fn move_action<const MILLIS: u64>() -> ActionSeed<StartAndEndPos, StartAndEndPos> {
-    wait::output(|In((start, end)): In<StartAndEndPos>,
-                  mut m: Query<&mut Transform, With<MrShape>>,
-                  mut tick: Local<f32>,
-                  time: Res<Time>| {
-        let mut t = m.single_mut();
-        let end_millis = Duration::from_millis(MILLIS).as_secs_f32();
-        *tick = end_millis.min(*tick + time.delta_seconds());
-        let d = *tick / end_millis;
-        t.translation = start + (end - start) * d;
-        ((*tick - end_millis).abs() < 0.01).then_some((start, end))
-    })
+    wait::output(
+        |In((start, end)): In<StartAndEndPos>,
+         mut m: Query<&mut Transform, With<MrShape>>,
+         mut tick: Local<f32>,
+         time: Res<Time>| {
+            let mut t = m.single_mut();
+            let end_millis = Duration::from_millis(MILLIS).as_secs_f32();
+            *tick = end_millis.min(*tick + time.delta_seconds());
+            let d = *tick / end_millis;
+            t.translation = start + (end - start) * d;
+            ((*tick - end_millis).abs() < 0.01).then_some((start, end))
+        },
+    )
 }
-
 
 fn push_move_track() -> ActionSeed<StartAndEndPos> {
     ActionSeed::define(|(start, end): StartAndEndPos| {
         static ID: AtomicUsize = AtomicUsize::new(0);
 
         record::push().with(Track {
-            act: MoveAct(ID.fetch_add(1, Ordering::Relaxed), format!("start: ({:03.0},{:03.0}) end: ({:03.0},{:03.0})", start.x, start.y, end.x, end.y)),
+            act: MoveAct(
+                ID.fetch_add(1, Ordering::Relaxed),
+                format!(
+                    "start: ({:03.0},{:03.0}) end: ({:03.0},{:03.0})",
+                    start.x, start.y, end.x, end.y
+                ),
+            ),
             rollback: Rollback::parts(
                 Undo::make(move || undo().with((start, end))),
                 Redo::make(move |_| redo().with((start, end))),
             ),
         })
     })
-        .omit_output()
+    .omit_output()
 }
 
 //noinspection DuplicatedCode
 fn undo() -> ActionSeed<StartAndEndPos> {
     ActionSeed::define(|(start, end): StartAndEndPos| {
-        makeup().with(bevy::prelude::Color::LinearRgba(LinearRgba::GREEN))
+        makeup()
+            .with(bevy::prelude::Color::LinearRgba(LinearRgba::GREEN))
             .then(move_action::<900>().with((end, start)))
             .then(makeup().with(Color::WHITE))
     })
@@ -200,14 +212,17 @@ fn undo() -> ActionSeed<StartAndEndPos> {
 //noinspection DuplicatedCode
 fn redo() -> ActionSeed<StartAndEndPos> {
     ActionSeed::define(|(start, end): StartAndEndPos| {
-        makeup().with(bevy::prelude::Color::LinearRgba(LinearRgba::GREEN))
+        makeup()
+            .with(bevy::prelude::Color::LinearRgba(LinearRgba::GREEN))
             .then(move_action::<900>().with((start, end)))
             .then(makeup().with(Color::WHITE))
     })
 }
 
 fn makeup() -> ActionSeed<Color> {
-    once::run(|In(color): In<Color>, mut sprite: Query<&mut Sprite, With<MrShape>>| {
-        sprite.single_mut().color = color;
-    })
+    once::run(
+        |In(color): In<Color>, mut sprite: Query<&mut Sprite, With<MrShape>>| {
+            sprite.single_mut().color = color;
+        },
+    )
 }

--- a/examples/undo_redo.rs
+++ b/examples/undo_redo.rs
@@ -170,7 +170,7 @@ fn move_action<const MILLIS: u64>() -> ActionSeed<StartAndEndPos, StartAndEndPos
          time: Res<Time>| {
             let mut t = m.single_mut();
             let end_millis = Duration::from_millis(MILLIS).as_secs_f32();
-            *tick = end_millis.min(*tick + time.delta_seconds());
+            *tick = end_millis.min(*tick + time.delta_secs());
             let d = *tick / end_millis;
             t.translation = start + (end - start) * d;
             ((*tick - end_millis).abs() < 0.01).then_some((start, end))

--- a/examples/undo_redo.rs
+++ b/examples/undo_redo.rs
@@ -13,10 +13,9 @@ use std::time::Duration;
 use bevy::app::{App, Startup, Update};
 use bevy::math::{Vec2, Vec3};
 use bevy::prelude::{
-    Camera2dBundle, Color, Commands, Component, EventWriter, In, KeyCode, LinearRgba, Local, Query,
-    Res, Sprite, Transform, With,
+    Camera2d, Color, Commands, Component, EventWriter, In, KeyCode, LinearRgba,
+    Local, Query, Res, Sprite, Transform, With,
 };
-use bevy::sprite::SpriteBundle;
 use bevy::time::Time;
 use bevy::utils::default;
 use bevy::DefaultPlugins;
@@ -53,18 +52,15 @@ fn main() {
 }
 
 fn spawn_camera(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 }
 
 fn spawn_mr_shape(mut commands: Commands) {
     commands.spawn((
         MrShape,
-        SpriteBundle {
-            sprite: Sprite {
-                custom_size: Some(Vec2::new(50., 50.)),
-                color: Color::WHITE,
-                ..default()
-            },
+        Sprite {
+            custom_size: Some(Vec2::new(50., 50.)),
+            color: Color::WHITE,
             ..default()
         },
     ));

--- a/src/action/effect/bevy_task/spawn.rs
+++ b/src/action/effect/bevy_task/spawn.rs
@@ -31,7 +31,7 @@ use crate::prelude::{ActionSeed, CancellationToken, Output, Runner};
 /// ```
 pub fn spawn<I, Out, Functor, M>(f: Functor) -> ActionSeed<I, Out>
 where
-    I: 'static,
+     I: 'static,
     Functor: AsyncFunctor<I, Out, M> + 'static,
     Out: Send + 'static,
     M: Send + 'static,

--- a/src/action/map.rs
+++ b/src/action/map.rs
@@ -7,8 +7,8 @@ use crate::runner::{BoxedRunner, Output, Runner};
 /// Maps an `Action<I1, O1>` to `Action<I1, O2>` or `ActionSeed<I1, O1>` to `ActionSeed<I1, O2>` by
 /// applying function.
 pub trait Map<I1, O1, O2, ActionOrSeed>: Sized
-    where
-        O2: 'static
+where
+    O2: 'static,
 {
     /// Maps an `Action<I1, O1>` to `Action<I1, O2>` or `ActionSeed<I1, O1>` to `ActionSeed<I1, O2>` by
     /// applying function.
@@ -52,21 +52,19 @@ pub trait Map<I1, O1, O2, ActionOrSeed>: Sized
 }
 
 impl<I, O, O2, A, Re> Map<I, O, O2, A> for Re
-    where
-        I: 'static,
-        O: 'static,
-        O2: 'static,
-        Re: Remake<I, O, O2, A> + 'static
+where
+     I: 'static,
+    O: 'static,
+    O2: 'static,
+    Re: Remake<I, O, O2, A> + 'static,
 {
     #[inline]
     fn map(self, f: impl FnOnce(O) -> O2 + 'static) -> A {
-        self.remake(|r1, o1, output| {
-            MapRunner {
-                r1,
-                o1,
-                output,
-                map: Some(f),
-            }
+        self.remake(|r1, o1, output| MapRunner {
+            r1,
+            o1,
+            output,
+            map: Some(f),
         })
     }
 }
@@ -79,7 +77,8 @@ struct MapRunner<O1, O2, F> {
 }
 
 impl<O1, O2, F> Runner for MapRunner<O1, O2, F>
-    where F: FnOnce(O1) -> O2 + 'static
+where
+    F: FnOnce(O1) -> O2 + 'static,
 {
     fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool {
         self.r1.run(world, token);
@@ -91,7 +90,6 @@ impl<O1, O2, F> Runner for MapRunner<O1, O2, F>
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -107,7 +105,8 @@ mod tests {
         let mut app = test_app();
         app.add_systems(Startup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(Update, once::run(|| 3).map(|num| format!("{num}"))).await;
+                task.will(Update, once::run(|| 3).map(|num| format!("{num}")))
+                    .await;
             }));
         });
     }
@@ -117,19 +116,25 @@ mod tests {
         let mut app = test_app();
         app.add_systems(Startup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(Update, once::run(|| 3)
-                    .overwrite(5)
-                    .pipe(once::run(|In(num): In<usize>| {
-                        assert_eq!(num, 5);
-                    })),
-                ).await;
+                task.will(
+                    Update,
+                    once::run(|| 3)
+                        .overwrite(5)
+                        .pipe(once::run(|In(num): In<usize>| {
+                            assert_eq!(num, 5);
+                        })),
+                )
+                .await;
 
-                task.will(Update, once::run(|| 3)
-                    .overwrite("string")
-                    .pipe(once::run(|In(str): In<&'static str>| {
-                        assert_eq!(str, "string");
-                    })),
-                ).await;
+                task.will(
+                    Update,
+                    once::run(|| 3).overwrite("string").pipe(once::run(
+                        |In(str): In<&'static str>| {
+                            assert_eq!(str, "string");
+                        },
+                    )),
+                )
+                .await;
             }));
         });
 
@@ -137,4 +142,3 @@ mod tests {
         app.update();
     }
 }
-

--- a/src/action/once/audio.rs
+++ b/src/action/once/audio.rs
@@ -3,11 +3,11 @@
 //! - [`once::audio::play`]
 
 use bevy::asset::{AssetPath, AssetServer};
-use bevy::audio::{AudioBundle, PlaybackSettings};
+use bevy::audio::{AudioPlayer, AudioSource};
 use bevy::prelude::{Commands, Entity, In, Res};
 
 use crate::action::once;
-use crate::prelude::{ActionSeed};
+use crate::prelude::ActionSeed;
 
 /// Spawns [`AudioBundle`].
 ///
@@ -22,18 +22,18 @@ use crate::prelude::{ActionSeed};
 /// use bevy_flurx::prelude::*;
 ///
 /// Reactor::schedule(|task| async move{
-///     task.will(Update, once::audio::play().with(("<audio_path>", PlaybackSettings::ONCE))).await;
+///     task.will(Update, once::audio::play().with("<audio_path>")).await;
 /// });
 /// ```
-pub fn play<Path>() -> ActionSeed<(Path, PlaybackSettings), Entity>
-    where Path: Into<AssetPath<'static>> + 'static
+pub fn play<Path>() -> ActionSeed<Path, Entity>
+where
+    Path: Into<AssetPath<'static>> + 'static,
 {
-    once::run(|In((path, settings)): In<(Path, PlaybackSettings)>, mut commands: Commands, asset_server: Res<AssetServer>| {
-        commands
-            .spawn(AudioBundle {
-                source: asset_server.load(path.into()),
-                settings,
-            })
-            .id()
-    })
+    once::run(
+        |In(path): In<Path>, mut commands: Commands, asset_server: Res<AssetServer>| {
+            commands
+                .spawn(AudioPlayer::<AudioSource>(asset_server.load(path.into())))
+                .id()
+        },
+    )
 }

--- a/src/action/once/non_send.rs
+++ b/src/action/once/non_send.rs
@@ -4,7 +4,6 @@
 //! - [`once::non_send::insert`]
 //! - [`once::non_send::remove`]
 
-
 use bevy::prelude::{In, World};
 
 use crate::action::once;
@@ -27,7 +26,8 @@ use crate::action::seed::ActionSeed;
 /// ```
 #[inline(always)]
 pub fn init<R>() -> ActionSeed
-    where R: Default + 'static
+where
+    R: Default + 'static,
 {
     once::run(|world: &mut World| {
         world.init_non_send_resource::<R>();
@@ -50,7 +50,8 @@ pub fn init<R>() -> ActionSeed
 /// ```
 #[inline(always)]
 pub fn insert<R>() -> ActionSeed<R>
-    where R: 'static
+where
+    R: 'static,
 {
     once::run(|In(resource): In<R>, world: &mut World| {
         world.insert_non_send_resource(resource);
@@ -73,13 +74,13 @@ pub fn insert<R>() -> ActionSeed<R>
 /// ```
 #[inline(always)]
 pub fn remove<R>() -> ActionSeed
-    where R: 'static
+where
+    R: 'static,
 {
     once::run(|world: &mut World| {
         world.remove_non_send_resource::<R>();
     })
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -100,7 +101,10 @@ mod tests {
         });
 
         app.update();
-        assert!(app.world().get_non_send_resource::<TestResource>().is_some());
+        assert!(app
+            .world()
+            .get_non_send_resource::<TestResource>()
+            .is_some());
     }
 
     #[test]
@@ -108,12 +112,16 @@ mod tests {
         let mut app = test_app();
         app.add_systems(Startup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(First, non_send::insert().with(TestResource)).await;
+                task.will(First, non_send::insert().with(TestResource))
+                    .await;
             }));
         });
 
         app.update();
-        assert!(app.world().get_non_send_resource::<TestResource>().is_some());
+        assert!(app
+            .world()
+            .get_non_send_resource::<TestResource>()
+            .is_some());
     }
 
     #[test]
@@ -127,7 +135,10 @@ mod tests {
             });
 
         app.update();
-        assert!(app.world().get_non_send_resource::<TestResource>().is_none());
+        assert!(app
+            .world()
+            .get_non_send_resource::<TestResource>()
+            .is_none());
     }
 
     #[test]
@@ -135,41 +146,64 @@ mod tests {
         let mut app = test_app();
         app.add_systems(Startup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(First, non_send::insert().with(AppExit::Success)).await;
+                task.will(First, non_send::insert().with(AppExit::Success))
+                    .await;
                 println!("First finished");
-                task.will(PreUpdate, non_send::insert().with(AppExit::Success)).await;
+                task.will(PreUpdate, non_send::insert().with(AppExit::Success))
+                    .await;
                 println!("PreUpdate finished");
-                task.will(Update, non_send::insert().with(AppExit::Success)).await;
+                task.will(Update, non_send::insert().with(AppExit::Success))
+                    .await;
                 println!("Update finished");
-                task.will(PostUpdate, non_send::insert().with(AppExit::Success)).await;
+                task.will(PostUpdate, non_send::insert().with(AppExit::Success))
+                    .await;
                 println!("PostUpdate finished");
-                task.will(Last, non_send::insert().with(AppExit::Success)).await;
+                task.will(Last, non_send::insert().with(AppExit::Success))
+                    .await;
                 println!("Last finished");
             }));
         });
 
         println!("First");
         app.update();
-        assert!(app.world_mut().remove_non_send_resource::<AppExit>().is_some());
+        assert!(app
+            .world_mut()
+            .remove_non_send_resource::<AppExit>()
+            .is_some());
 
         println!("PreUpdate");
         app.update();
-        assert!(app.world_mut().remove_non_send_resource::<AppExit>().is_some());
+        assert!(app
+            .world_mut()
+            .remove_non_send_resource::<AppExit>()
+            .is_some());
 
         println!("Update");
         app.update();
-        assert!(app.world_mut().remove_non_send_resource::<AppExit>().is_some());
+        assert!(app
+            .world_mut()
+            .remove_non_send_resource::<AppExit>()
+            .is_some());
 
         println!("PostUpdate");
         app.update();
-        assert!(app.world_mut().remove_non_send_resource::<AppExit>().is_some());
+        assert!(app
+            .world_mut()
+            .remove_non_send_resource::<AppExit>()
+            .is_some());
 
         println!("Last");
         app.update();
-        assert!(app.world_mut().remove_non_send_resource::<AppExit>().is_some());
+        assert!(app
+            .world_mut()
+            .remove_non_send_resource::<AppExit>()
+            .is_some());
 
         println!("After Reactor Finished");
         app.update();
-        assert!(app.world_mut().remove_non_send_resource::<AppExit>().is_none());
+        assert!(app
+            .world_mut()
+            .remove_non_send_resource::<AppExit>()
+            .is_none());
     }
 }

--- a/src/action/record/extension.rs
+++ b/src/action/record/extension.rs
@@ -1,4 +1,4 @@
-//! Allows undo and redo requests to be made using [`RequestUndo`] and [`RequestRedo`] 
+//! Allows undo and redo requests to be made using [`RequestUndo`] and [`RequestRedo`]
 //! from outside [`Reactor`].
 //!
 //! events
@@ -7,7 +7,6 @@
 //!
 //! traits
 //! - [`RecordExtension`]
-
 
 use bevy::app::{App, PostUpdate, Update};
 use bevy::prelude::{Commands, Event, EventReader};
@@ -51,36 +50,29 @@ pub enum RequestRedo<Act> {
     All,
 }
 
-/// Allows undo and redo requests to be made using [`RequestUndo`] and [`RequestRedo`] 
+/// Allows undo and redo requests to be made using [`RequestUndo`] and [`RequestRedo`]
 /// from outside [`Reactor`].
 pub trait RecordExtension {
     /// Set up [`RequestUndo`] and [`RequestRedo`] and their associated systems.
     fn add_record_events<Act>(&mut self) -> &mut Self
-        where
-            Act: Clone + PartialEq + Send + Sync + 'static;
+    where
+        Act: Clone + PartialEq + Send + Sync + 'static;
 }
 
 impl RecordExtension for App {
     fn add_record_events<Act>(&mut self) -> &mut Self
-        where
-            Act: Clone + PartialEq + Send + Sync + 'static
+    where
+        Act: Clone + PartialEq + Send + Sync + 'static,
     {
-        self
-            .add_event::<RequestUndo<Act>>()
+        self.add_event::<RequestUndo<Act>>()
             .add_event::<RequestRedo<Act>>()
-            .add_systems(PostUpdate, (
-                request_undo::<Act>,
-                request_redo::<Act>
-            ))
+            .add_systems(PostUpdate, (request_undo::<Act>, request_redo::<Act>))
     }
 }
 
-fn request_undo<Act>(
-    mut commands: Commands,
-    mut er: EventReader<RequestUndo<Act>>,
-)
-    where
-        Act: Clone + Send + PartialEq + Sync + 'static
+fn request_undo<Act>(mut commands: Commands, mut er: EventReader<RequestUndo<Act>>)
+where
+    Act: Clone + Send + PartialEq + Sync + 'static,
 {
     if let Some(actions) = er
         .read()
@@ -88,23 +80,19 @@ fn request_undo<Act>(
             RequestUndo::To(act) => record::undo::to().with(act.clone()).omit(),
             RequestUndo::IndexTo(i) => record::undo::index_to::<Act>().with(*i).omit(),
             RequestUndo::Once => record::undo::once::<Act>().omit(),
-            RequestUndo::All => record::undo::all::<Act>().omit()
+            RequestUndo::All => record::undo::all::<Act>().omit(),
         })
-        .reduce(|r1, r2| {
-            r1.then(r2)
-        }) {
+        .reduce(|r1, r2| r1.then(r2))
+    {
         commands.spawn(Reactor::schedule(|task| async move {
             task.will(Update, actions).await;
         }));
     }
 }
 
-fn request_redo<Act>(
-    mut commands: Commands,
-    mut er: EventReader<RequestRedo<Act>>,
-)
-    where
-        Act: Clone + Send + PartialEq + Sync + 'static
+fn request_redo<Act>(mut commands: Commands, mut er: EventReader<RequestRedo<Act>>)
+where
+    Act: Clone + Send + PartialEq + Sync + 'static,
 {
     if let Some(actions) = er
         .read()
@@ -112,11 +100,10 @@ fn request_redo<Act>(
             RequestRedo::To(act) => record::redo::to().with(act.clone()).omit(),
             RequestRedo::IndexTo(i) => record::redo::index_to::<Act>().with(*i).omit(),
             RequestRedo::Once => record::redo::once::<Act>().omit(),
-            RequestRedo::All => record::redo::all::<Act>().omit()
+            RequestRedo::All => record::redo::all::<Act>().omit(),
         })
-        .reduce(|r1, r2| {
-            r1.then(r2)
-        }) {
+        .reduce(|r1, r2| r1.then(r2))
+    {
         commands.spawn(Reactor::schedule(|task| async move {
             task.will(Update, actions).await;
         }));
@@ -133,9 +120,9 @@ mod tests {
     use bevy_test_helper::resource::DirectResourceControl;
 
     use crate::action::record::tests::push_undo_increment;
-    use crate::prelude::{Reactor, RequestRedo, RequestUndo, Then};
     use crate::prelude::record::tests::push_num_act;
-    use crate::tests::{NumAct, test_app, TestAct};
+    use crate::prelude::{Reactor, RequestRedo, RequestUndo, Then};
+    use crate::tests::{test_app, NumAct, TestAct};
 
     #[test]
     fn test_request_undo_once() {
@@ -158,10 +145,14 @@ mod tests {
         let mut app = test_app();
         app.add_systems(PreStartup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(Update, push_undo_increment()
-                    .then(push_undo_increment())
-                    .then(push_undo_increment()),
-                ).await.unwrap();
+                task.will(
+                    Update,
+                    push_undo_increment()
+                        .then(push_undo_increment())
+                        .then(push_undo_increment()),
+                )
+                .await
+                .unwrap();
             }));
         });
         app.add_systems(Startup, |mut ew: EventWriter<RequestUndo<TestAct>>| {
@@ -177,10 +168,11 @@ mod tests {
         let mut app = test_app();
         app.add_systems(PreStartup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(Update, push_num_act(0)
-                    .then(push_num_act(1))
-                    .then(push_num_act(2)),
-                ).await;
+                task.will(
+                    Update,
+                    push_num_act(0).then(push_num_act(1)).then(push_num_act(2)),
+                )
+                .await;
             }));
         });
         app.add_systems(Startup, |mut ew: EventWriter<RequestUndo<NumAct>>| {
@@ -196,10 +188,14 @@ mod tests {
         let mut app = test_app();
         app.add_systems(PreStartup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(Update, push_undo_increment()
-                    .then(push_undo_increment())
-                    .then(push_undo_increment()),
-                ).await.unwrap();
+                task.will(
+                    Update,
+                    push_undo_increment()
+                        .then(push_undo_increment())
+                        .then(push_undo_increment()),
+                )
+                .await
+                .unwrap();
             }));
         });
         app.add_systems(Startup, |mut ew: EventWriter<RequestUndo<TestAct>>| {
@@ -215,19 +211,25 @@ mod tests {
         let mut app = test_app();
         app.add_systems(PreStartup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(Update, push_undo_increment()
-                    .then(push_undo_increment())
-                    .then(push_undo_increment()),
-                ).await.unwrap();
+                task.will(
+                    Update,
+                    push_undo_increment()
+                        .then(push_undo_increment())
+                        .then(push_undo_increment()),
+                )
+                .await
+                .unwrap();
             }));
         });
         app.add_systems(Startup, |mut ew: EventWriter<RequestUndo<TestAct>>| {
             ew.send(RequestUndo::All);
         });
         app.update();
-        app.world_mut().run_system_once(|mut ew: EventWriter<RequestRedo<TestAct>>| {
-            ew.send(RequestRedo::Once);
-        });
+        app.world_mut()
+            .run_system_once(|mut ew: EventWriter<RequestRedo<TestAct>>| {
+                ew.send(RequestRedo::Once);
+            })
+            .expect("Failed to run system");
         app.update();
         app.update();
         app.assert_resource_eq(Count(2));
@@ -238,19 +240,25 @@ mod tests {
         let mut app = test_app();
         app.add_systems(PreStartup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(Update, push_undo_increment()
-                    .then(push_undo_increment())
-                    .then(push_undo_increment()),
-                ).await.unwrap();
+                task.will(
+                    Update,
+                    push_undo_increment()
+                        .then(push_undo_increment())
+                        .then(push_undo_increment()),
+                )
+                .await
+                .unwrap();
             }));
         });
         app.add_systems(Startup, |mut ew: EventWriter<RequestUndo<TestAct>>| {
             ew.send(RequestUndo::All);
         });
         app.update();
-        app.world_mut().run_system_once(|mut ew: EventWriter<RequestRedo<TestAct>>| {
-            ew.send(RequestRedo::IndexTo(1));
-        });
+        app.world_mut()
+            .run_system_once(|mut ew: EventWriter<RequestRedo<TestAct>>| {
+                ew.send(RequestRedo::IndexTo(1));
+            })
+            .expect("Failed to run system");
         app.update();
         app.update();
         app.assert_resource_eq(Count(1));
@@ -261,19 +269,22 @@ mod tests {
         let mut app = test_app();
         app.add_systems(PreStartup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(Update, push_num_act(0)
-                    .then(push_num_act(1))
-                    .then(push_num_act(2)),
-                ).await;
+                task.will(
+                    Update,
+                    push_num_act(0).then(push_num_act(1)).then(push_num_act(2)),
+                )
+                .await;
             }));
         });
         app.add_systems(Startup, |mut ew: EventWriter<RequestUndo<NumAct>>| {
             ew.send(RequestUndo::All);
         });
         app.update();
-        app.world_mut().run_system_once(|mut ew: EventWriter<RequestRedo<NumAct>>| {
-            ew.send(RequestRedo::To(NumAct(1)));
-        });
+        app.world_mut()
+            .run_system_once(|mut ew: EventWriter<RequestRedo<NumAct>>| {
+                ew.send(RequestRedo::To(NumAct(1)));
+            })
+            .expect("Failed to run system");
         app.update();
         app.update();
         app.assert_resource_eq(Count(1));
@@ -284,19 +295,22 @@ mod tests {
         let mut app = test_app();
         app.add_systems(PreStartup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
-                task.will(Update, push_num_act(0)
-                    .then(push_num_act(1))
-                    .then(push_num_act(2)),
-                ).await;
+                task.will(
+                    Update,
+                    push_num_act(0).then(push_num_act(1)).then(push_num_act(2)),
+                )
+                .await;
             }));
         });
         app.add_systems(Startup, |mut ew: EventWriter<RequestUndo<NumAct>>| {
             ew.send(RequestUndo::All);
         });
         app.update();
-        app.world_mut().run_system_once(|mut ew: EventWriter<RequestRedo<NumAct>>| {
-            ew.send(RequestRedo::All);
-        });
+        app.world_mut()
+            .run_system_once(|mut ew: EventWriter<RequestRedo<NumAct>>| {
+                ew.send(RequestRedo::All);
+            })
+            .expect("Failed to run system");
         app.update();
         app.update();
         app.assert_resource_eq(Count(0));

--- a/src/action/record/push.rs
+++ b/src/action/record/push.rs
@@ -1,9 +1,9 @@
 use bevy::prelude::World;
 
 use crate::action::record::push_track;
-use crate::prelude::{ActionSeed, CancellationToken, Output, Runner};
 use crate::prelude::record::EditRecordResult;
 use crate::prelude::record::Track;
+use crate::prelude::{ActionSeed, CancellationToken, Output, Runner};
 
 /// Push the [`Track`](crate::prelude::Track) onto the [`Record`](crate::prelude::Record).
 ///
@@ -14,7 +14,6 @@ use crate::prelude::record::Track;
 /// ```no_run
 ///
 /// use bevy::prelude::*;
-/// use bevy::window::CursorIcon::Move;
 /// use futures::SinkExt;
 /// use bevy_flurx::prelude::*;
 ///
@@ -37,14 +36,12 @@ use crate::prelude::record::Track;
 /// });
 /// ```
 pub fn push<Act>() -> ActionSeed<Track<Act>, EditRecordResult>
-    where
-        Act: Send + Sync + 'static,
+where
+    Act: Send + Sync + 'static,
 {
-    ActionSeed::new(|track: Track<Act>, output| {
-        PushRunner {
-            output,
-            track: Some(track),
-        }
+    ActionSeed::new(|track: Track<Act>, output| PushRunner {
+        output,
+        track: Some(track),
     })
 }
 
@@ -54,8 +51,8 @@ struct PushRunner<Act> {
 }
 
 impl<Act> Runner for PushRunner<Act>
-    where
-        Act: Send + Sync + 'static
+where
+    Act: Send + Sync + 'static,
 {
     fn run(&mut self, world: &mut World, _: &CancellationToken) -> bool {
         if let Some(track) = self.track.take() {
@@ -69,18 +66,17 @@ impl<Act> Runner for PushRunner<Act>
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use bevy::app::Startup;
     use bevy::prelude::{Commands, Update};
     use bevy_test_helper::resource::DirectResourceControl;
 
-    use crate::action::{once, record};
     use crate::action::record::{Record, Track};
+    use crate::action::{once, record};
     use crate::prelude::{ActionSeed, Omit, Reactor, Rollback};
 
-    use crate::tests::{test_app};
+    use crate::tests::test_app;
 
     #[derive(Default)]
     struct H1;
@@ -138,12 +134,11 @@ mod tests {
     }
 
     fn push<Act: Send + Sync + 'static>(act: Act) -> ActionSeed {
-        record::push().with(Track {
-            act,
-            rollback: Rollback::undo(|| {
-                once::run(|| {})
-            }),
-        })
+        record::push()
+            .with(Track {
+                act,
+                rollback: Rollback::undo(|| once::run(|| {})),
+            })
             .omit()
     }
 }

--- a/src/action/record/track.rs
+++ b/src/action/record/track.rs
@@ -54,7 +54,7 @@ impl Rollback {
     /// ```
     pub fn new<I, A, F>(f: F) -> Self
         where
-            I: 'static,
+             I: 'static,
             F: Fn() -> A + 'static,
             A: Into<Action<I, Option<RedoAction>>> + 'static,
     {
@@ -75,7 +75,7 @@ impl Rollback {
     /// ```
     pub fn undo<I, O, A, F>(f: F) -> Self
         where
-            I: 'static,
+             I: 'static,
             O: 'static,
             F: Fn() -> A + 'static,
             A: Into<Action<I, O>> + 'static,
@@ -100,7 +100,7 @@ impl Rollback {
     /// ```
     pub fn undo_redo<I, A, F>(f: F) -> Self
         where
-            I: 'static,
+             I: 'static,
             F: Fn() -> A + 'static,
             A: Into<Action<I, RedoAction>> + 'static,
     {
@@ -145,7 +145,7 @@ impl Rollback {
         redo: (Option<RF>, PhantomData<(RI, O, RO, RA)>),
     ) -> Self
         where
-            I: 'static,
+             I: 'static,
             O: 'static,
             F: Fn() -> A + 'static,
             A: Into<Action<I, O>> + 'static,

--- a/src/action/seed.rs
+++ b/src/action/seed.rs
@@ -1,5 +1,4 @@
-//! Provides the trait for converting into an action. 
-
+//! Provides the trait for converting into an action.
 
 use crate::action::Action;
 use crate::runner::{BoxedRunner, Output, Runner};
@@ -12,21 +11,21 @@ use crate::runner::{BoxedRunner, Output, Runner};
 ///
 /// [`Action`]: crate::prelude::Action
 /// [`Pipe::pipe`]: crate::prelude::Pipe::pipe
-/// 
+///
 ///
 #[repr(transparent)]
 pub struct ActionSeed<I = (), O = ()>(Box<dyn FnOnce(I, Output<O>) -> BoxedRunner>);
 
 impl<I, O> ActionSeed<I, O>
-    where
-        I: 'static,
-        O: 'static
+where
+    I: 'static,
+    O: 'static,
 {
     /// Create the [`ActionSeed`].
     #[inline]
     pub fn new<R>(f: impl FnOnce(I, Output<O>) -> R + 'static) -> ActionSeed<I, O>
-        where
-            R: Runner + 'static
+    where
+        R: Runner + 'static,
     {
         ActionSeed(Box::new(move |input, output| {
             BoxedRunner::new(f(input, output))
@@ -51,13 +50,11 @@ impl<I, O> ActionSeed<I, O>
     /// ```
     #[inline]
     pub fn define<I2, A>(f: impl FnOnce(I) -> A + 'static) -> ActionSeed<I, O>
-        where
-            I2: 'static,
-            A: Into<Action<I2, O>>
+    where
+        I2: 'static,
+        A: Into<Action<I2, O>>,
     {
-        ActionSeed::from(|input, output| {
-            f(input).into().into_runner(output)
-        })
+        ActionSeed::from(|input, output| f(input).into().into_runner(output))
     }
 
     /// Into [`Action`] with `input`.
@@ -75,14 +72,11 @@ impl<I, O> ActionSeed<I, O>
 }
 
 impl<I, O, F> From<F> for ActionSeed<I, O>
-    where
-        F: FnOnce(I, Output<O>) -> BoxedRunner + 'static
+where
+    F: FnOnce(I, Output<O>) -> BoxedRunner + 'static,
 {
     #[inline]
     fn from(value: F) -> Self {
         Self(Box::new(value))
     }
 }
-
-
-

--- a/src/action/tuple.rs
+++ b/src/action/tuple.rs
@@ -4,10 +4,10 @@ use crate::prelude::{ActionSeed, CancellationToken};
 use crate::runner::{BoxedRunner, Output, Runner};
 
 /// Convert to the output of action to tuple.
-pub fn tuple<I, O>(action: ActionSeed<I, O>) -> ActionSeed<I, (O, )>
-    where
-        I: 'static,
-        O: 'static
+pub fn tuple<I, O>(action: ActionSeed<I, O>) -> ActionSeed<I, (O,)>
+where
+    I: 'static,
+    O: 'static,
 {
     ActionSeed::new(|input, output| {
         let tmp = Output::default();
@@ -15,7 +15,7 @@ pub fn tuple<I, O>(action: ActionSeed<I, O>) -> ActionSeed<I, (O, )>
         TupleRunner {
             runner,
             tmp,
-            output
+            output,
         }
     })
 }
@@ -23,14 +23,14 @@ pub fn tuple<I, O>(action: ActionSeed<I, O>) -> ActionSeed<I, (O, )>
 struct TupleRunner<O> {
     runner: BoxedRunner,
     tmp: Output<O>,
-    output: Output<(O, )>
+    output: Output<(O,)>,
 }
 
 impl<O> Runner for TupleRunner<O> {
     fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool {
         self.runner.run(world, token);
         if let Some(o) = self.tmp.take() {
-            self.output.set((o, ));
+            self.output.set((o,));
             true
         } else {
             false

--- a/src/action/wait/all.rs
+++ b/src/action/wait/all.rs
@@ -25,8 +25,8 @@ use crate::runner::{BoxedRunner, CancellationToken};
 /// });
 /// ```
 pub fn all<Actions>() -> ActionSeed<Actions>
-    where
-        Actions: IntoIterator<Item=ActionSeed> + 'static,
+where
+    Actions: IntoIterator<Item = ActionSeed> + 'static,
 {
     ActionSeed::new(|actions: Actions, output| AllRunner {
         runners: actions
@@ -113,8 +113,8 @@ pub mod private {
 
     use crate::action::Action;
     use crate::prelude::ActionSeed;
-    use crate::runner::{BoxedRunner, Output, Runner};
     use crate::runner::macros::impl_tuple_runner;
+    use crate::runner::{BoxedRunner, Output, Runner};
 
     pub struct FlatBothRunner<I1, I2, O1, O2, O> {
         o1: Output<O1>,
@@ -205,7 +205,7 @@ mod tests {
 
     use crate::action::delay;
     use crate::actions;
-    use crate::prelude::{once, Pipe, Then, wait};
+    use crate::prelude::{once, wait, Pipe, Then};
     use crate::reactor::Reactor;
     use crate::test_util::SpawnReactor;
     use crate::tests::{decrement_count, exit_reader, increment_count, test_app};
@@ -218,7 +218,7 @@ mod tests {
                 once::run(|| [increment_count(), increment_count(), decrement_count()])
                     .pipe(wait::all())
             })
-                .await;
+            .await;
         });
         app.update();
         app.assert_resource_eq(Count(1));
@@ -236,10 +236,10 @@ mod tests {
                         increment_count()
                     ]
                 })
-                    .pipe(wait::all())
-                    .then(once::event::app_exit_success())
+                .pipe(wait::all())
+                .then(once::event::app_exit_success())
             })
-                .await;
+            .await;
         });
         let mut er = exit_reader();
         app.update();
@@ -278,11 +278,15 @@ mod tests {
 
         app.update();
 
-        app.world_mut().run_system_once(|mut w: EventWriter<TestEvent1>| w.send(TestEvent1));
+        app.world_mut()
+            .run_system_once(|mut w: EventWriter<TestEvent1>| w.send(TestEvent1))
+            .expect("Failed to run system");
         app.update();
         assert!(app.world().get_non_send_resource::<AppExit>().is_none());
 
-        app.world_mut().run_system_once(|mut w: EventWriter<TestEvent2>| w.send(TestEvent2));
+        app.world_mut()
+            .run_system_once(|mut w: EventWriter<TestEvent2>| w.send(TestEvent2))
+            .expect("Failed to run system");
         app.update();
         assert!(app.world().get_non_send_resource::<AppExit>().is_none());
 

--- a/src/action/wait/audio.rs
+++ b/src/action/wait/audio.rs
@@ -6,33 +6,36 @@ use bevy::audio::{AudioSink, AudioSinkPlayback};
 use bevy::prelude::{Commands, Entity, In, Query};
 
 use crate::action::wait;
-use crate::prelude::seed::{ActionSeed, };
+use crate::prelude::seed::ActionSeed;
 
 /// Waits until the audio associated with the passed [`Entity`] has finished playing.
 ///
 /// ## Examples
-/// 
+///
 /// ```no_run
 /// use bevy::prelude::*;
 /// use bevy_flurx::prelude::*;
 ///
 /// Reactor::schedule(|task| async move{
 ///     task.will(Update, {
-///         once::audio::play().with(("<audio_path>", PlaybackSettings::ONCE))
+///         once::audio::play()
+///             .with("<audio_path>")
 ///             .pipe(wait::audio::finished())
 ///     }).await;
 /// });
 /// ```
 pub fn finished() -> ActionSeed<Entity, ()> {
-    wait::until(|In(entity): In<Entity>,
-                 mut commands: Commands,
-                 audio: Query<(Entity, &AudioSink)>| {
-        let Ok((entity, audio)) = audio.get(entity) else { return false; };
-        if audio.empty() {
-            commands.entity(entity).despawn();
-            true
-        } else {
-            false
-        }
-    })
+    wait::until(
+        |In(entity): In<Entity>, mut commands: Commands, audio: Query<(Entity, &AudioSink)>| {
+            let Ok((entity, audio)) = audio.get(entity) else {
+                return false;
+            };
+            if audio.empty() {
+                commands.entity(entity).despawn();
+                true
+            } else {
+                false
+            }
+        },
+    )
 }

--- a/src/action/wait/either.rs
+++ b/src/action/wait/either.rs
@@ -28,7 +28,6 @@ impl<L, R> Either<L, R> {
     }
 }
 
-
 /// Waits until either of the two tasks is completed.
 ///
 /// The first thing passed is lhs, the second is rhs.
@@ -52,15 +51,15 @@ impl<L, R> Either<L, R> {
 /// });
 /// ```
 #[inline(always)]
-pub fn either<LI, LO, RI, RO, >(
+pub fn either<LI, LO, RI, RO>(
     lhs: impl Into<Action<LI, LO>> + 'static,
     rhs: impl Into<Action<RI, RO>> + 'static,
 ) -> Action<(LI, RI), Either<LO, RO>>
-    where
-        LI: 'static,
-        LO: 'static,
-        RI: 'static,
-        RO: 'static,
+where
+    LI: 'static,
+    LO: 'static,
+    RI: 'static,
+    RO: 'static,
 {
     let Action(li, ls) = lhs.into();
     let Action(ri, rs) = rhs.into();
@@ -75,7 +74,7 @@ pub fn either<LI, LO, RI, RO, >(
             output,
         }
     })
-        .with((li, ri))
+    .with((li, ri))
 }
 
 struct EitherRunner<O1, O2> {
@@ -87,9 +86,9 @@ struct EitherRunner<O1, O2> {
 }
 
 impl<O1, O2> Runner for EitherRunner<O1, O2>
-    where
-        O1: 'static,
-        O2: 'static,
+where
+    O1: 'static,
+    O2: 'static,
 {
     fn run(&mut self, world: &mut World, token: &CancellationToken) -> bool {
         self.r1.run(world, token);
@@ -107,7 +106,6 @@ impl<O1, O2> Runner for EitherRunner<O1, O2>
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use bevy::ecs::system::RunSystemOnce;
@@ -115,8 +113,8 @@ mod tests {
     use bevy::prelude::{Commands, KeyCode, Local, ResMut, Resource, Update};
     use bevy_test_helper::resource::DirectResourceControl;
 
+    use crate::action::wait::{output, until, Either};
     use crate::action::{once, wait};
-    use crate::action::wait::{Either, output, until};
     use crate::reactor::Reactor;
     use crate::tests::test_app;
     use crate::wait_all;
@@ -126,23 +124,26 @@ mod tests {
         let mut app = test_app();
         #[derive(Clone)]
         struct Count(usize);
-        app.world_mut().run_system_once(|mut commands: Commands| {
-            commands.spawn(Reactor::schedule(|task| async move {
-                let u1 = until(|mut count: Local<u32>| {
-                    *count += 1;
-                    *count == 3
-                });
+        app.world_mut()
+            .run_system_once(|mut commands: Commands| {
+                commands.spawn(Reactor::schedule(|task| async move {
+                    let u1 = until(|mut count: Local<u32>| {
+                        *count += 1;
+                        *count == 3
+                    });
 
-                let u2 = output(|mut count: Local<u32>| {
-                    *count += 1;
-                    (*count == 2).then_some(1)
-                });
+                    let u2 = output(|mut count: Local<u32>| {
+                        *count += 1;
+                        (*count == 2).then_some(1)
+                    });
 
-                if let Either::Right(rhs) = task.will(Update, wait::either(u1, u2)).await {
-                    task.will(Update, once::non_send::insert().with(Count(rhs))).await;
-                }
-            }));
-        });
+                    if let Either::Right(rhs) = task.will(Update, wait::either(u1, u2)).await {
+                        task.will(Update, once::non_send::insert().with(Count(rhs)))
+                            .await;
+                    }
+                }));
+            })
+            .expect("Failed to run system");
 
         app.update();
         assert!(app.world().get_non_send_resource::<Count>().is_none());
@@ -161,23 +162,30 @@ mod tests {
         let mut app = test_app();
         app.init_resource::<Count>();
 
-        app.world_mut().run_system_once(|mut commands: Commands| {
-            commands.spawn(Reactor::schedule(|task| async move {
-                task.will(Update, wait::either(
-                    wait_all! {
-                        wait::until(|mut count:ResMut<Count>| {
-                            count.0 += 1;
-                            false
-                        }),
-                        wait::until(|| { false })
-                    },
-                    wait::input::pressed().with(KeyCode::KeyA),
-                )).await;
-                task.will(Update, wait::until(|| { false })).await;
-            }));
-        });
+        app.world_mut()
+            .run_system_once(|mut commands: Commands| {
+                commands.spawn(Reactor::schedule(|task| async move {
+                    task.will(
+                        Update,
+                        wait::either(
+                            wait_all! {
+                                wait::until(|mut count:ResMut<Count>| {
+                                    count.0 += 1;
+                                    false
+                                }),
+                                wait::until(|| { false })
+                            },
+                            wait::input::pressed().with(KeyCode::KeyA),
+                        ),
+                    )
+                    .await;
+                    task.will(Update, wait::until(|| false)).await;
+                }));
+            })
+            .expect("Failed to run system");
 
-        app.resource_mut::<ButtonInput<KeyCode>>().press(KeyCode::KeyA);
+        app.resource_mut::<ButtonInput<KeyCode>>()
+            .press(KeyCode::KeyA);
         for _ in 0..100 {
             app.update();
             app.assert_resource_eq(Count(1));

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -32,7 +32,7 @@ where
     }
 }
 
-impl<'w, 'b, F, Fut> ScheduleReactor<'w, F, Fut, ()> for &mut Commands<'w, 'b>
+impl<'w, F, Fut> ScheduleReactor<'w, F, Fut, ()> for &mut Commands<'w, '_>
 where
     F: FnOnce(ReactiveTask) -> Fut + Send + 'static,
     Fut: Future + 'static,


### PR DESCRIPTION
- Support bevy0.15.0
- Removed the flag for the `multi-thread` feature of bevy, which was depended upon internally in this lib.