### PR TITLE
update: specifying versions of dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UnReleased
+
+- To support a wider range of versions, the dependency libraries are now specified by their major version.
+
 ## v0.9.0
 
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.9.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,22 +30,22 @@ name = "switch_just_change"
 path = "examples/bug_check/switch_just_change.rs"
 
 [dependencies]
-bevy = { version = "0.15.0", default-features = false, features = [] }
-futures-polling = "0.1.1"
-futures-lite = "2.5.0"
-pollster = "0.4.0"
-pin-project = "1.1.7"
-tokio = { version = "1.42.0", optional = true, features = ["sync", "time"] }
+bevy = { version = "0.15", default-features = false, features = [] }
+futures-polling = "0.1"
+futures-lite = "2"
+pollster = "0.4"
+pin-project = "1"
+tokio = { version = "1", optional = true, features = ["sync", "time"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-async-compat = { version = "0.2.3", optional = true }
+async-compat = { version = "0.2", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15.0" }
+bevy = { version = "0.15" }
 bevy_test_helper = { git = "https://github.com/not-elm/bevy_test_helper", branch = "v0.15.0" }
-futures = "0.3.31"
-criterion = { version = "0.5.1", features = ["plotters", "html_reports"] }
-bevy_egui = "0.32.0"
+futures = "0.3"
+criterion = { version = "0.5", features = ["plotters", "html_reports"] }
+bevy_egui = "0.32"
 
 [features]
 default = []


### PR DESCRIPTION
To support a wider range of versions, the dependency libraries are now specified by their major version.