### PR TITLE
update: ultra super optimized reactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
 ## Unreleased
 
+### Features
+
+- Added `StepAllReactors` and `StepReactor` trigger events to step the reactor manually; please see this [example](./examples/side_effect.rs)
+
+### Breaking Changes
+
+- The reactor now steps immediately when each runner completes processing.
+- From this version onward, if you invoke asynchronous processing other than an Action within the reactor’s async block as shown below, you will need to manually advance the reactor by triggering either StepAllReactors or StepReactor.
+
 ### Improvements
 
 - Improved the delay until the callback is invoked when the reactor is canceled
+- Significantly improved performance.
 
 ## v0.9.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_flurx"
 version = "0.9.1"
-edition = "2024"
+edition = "2021"
 authors = ["notelm <elmprograminfo@gmail.com>"]
 categories = ["asynchronous", "game-development"]
 description = "Allows you to use coroutine in Bevy"
@@ -40,6 +40,8 @@ futures-polling = "0.1"
 futures-lite = "2"
 pollster = "0.4"
 pin-project = "1"
+itertools = "0.14.0"
+serde = { version = "1", features = ["derive"]}
 tokio = { version = "1", optional = true, features = ["sync", "time"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/examples/side_effect.rs
+++ b/examples/side_effect.rs
@@ -17,6 +17,7 @@ fn main() {
             FlurxPlugin,
         ))
         .add_systems(Startup, spawn_reactor)
+        .add_systems(Update, step_reactors)
         .run();
 }
 
@@ -34,6 +35,7 @@ fn spawn_reactor(mut commands: Commands) {
                 }))
         }).await;
 
+        // *1
         // By turning on feature flag `tokio`,
         // you can also directly write asynchronous functions depending on tokio's runtime in the reactor.
         tokio::time::sleep(Duration::from_secs(1)).await;
@@ -43,3 +45,10 @@ fn spawn_reactor(mut commands: Commands) {
     }));
 }
 
+/// If you perform asynchronous processing other than actions in the reactor (in this example, *1), 
+/// you need to manually update the reactor.
+fn step_reactors(
+    mut commands: Commands,
+){
+    commands.trigger(StepAllReactors);
+}

--- a/examples/side_effect.rs
+++ b/examples/side_effect.rs
@@ -17,9 +17,11 @@ fn main() {
             FlurxPlugin,
         ))
         .add_systems(Startup, spawn_reactor)
-        .add_systems(Update, step_reactors)
+        .add_systems(Update, step_reactors.run_if(switch_is_on::<TokioTaskRunning>))
         .run();
 }
+
+struct TokioTaskRunning;
 
 fn spawn_reactor(mut commands: Commands) {
     commands.spawn(Reactor::schedule(|task| async move {
@@ -35,18 +37,19 @@ fn spawn_reactor(mut commands: Commands) {
                 }))
         }).await;
 
-        // *1
+        task.will(Update, once::switch::on::<TokioTaskRunning>()).await;
+        
         // By turning on feature flag `tokio`,
         // you can also directly write asynchronous functions depending on tokio's runtime in the reactor.
+        // However, you need to manually advance the reactor.
         tokio::time::sleep(Duration::from_secs(1)).await;
+        task.will(Update, once::switch::off::<TokioTaskRunning>()).await;
 
         info!("Done!");
         task.will(Update, once::event::app_exit_success()).await;
     }));
 }
 
-/// If you perform asynchronous processing other than actions in the reactor (in this example, *1), 
-/// you need to manually update the reactor.
 fn step_reactors(
     mut commands: Commands,
 ){

--- a/src/action/once/switch.rs
+++ b/src/action/once/switch.rs
@@ -1,10 +1,9 @@
 //! [`once::switch`] creates a task that only once run system related to [`Switch`].
 
-
-use bevy::prelude::World;
 use crate::action::once;
 use crate::action::seed::ActionSeed;
 use crate::action::switch::Switch;
+use bevy::prelude::World;
 
 
 /// Turns [`Switch`] on.
@@ -56,13 +55,13 @@ pub fn off<M>() -> ActionSeed
 
 #[cfg(test)]
 mod tests {
-    use bevy::app::Startup;
-    use bevy::prelude::{Commands, IntoSystemConfigs, ResMut, Update};
-    use bevy_test_helper::resource::bool::{Bool, BoolExtension};
-    use crate::action::once;
+    use crate::action::{delay, once};
     use crate::prelude::{switch_just_turned_off, switch_just_turned_on};
     use crate::reactor::Reactor;
     use crate::tests::test_app;
+    use bevy::app::{PostUpdate, Startup};
+    use bevy::prelude::{Commands, IntoSystemConfigs, ResMut, Update};
+    use bevy_test_helper::resource::bool::{Bool, BoolExtension};
 
     struct T;
 
@@ -89,7 +88,7 @@ mod tests {
         app
             .add_systems(Startup, |mut commands: Commands| {
                 commands.spawn(Reactor::schedule(|task| async move {
-                    task.will(Update, once::run(|| {})).await;
+                    task.will(Update, delay::frames().with(1)).await;
                     task.will(Update, once::switch::on::<T>()).await;
                 }));
             })
@@ -126,17 +125,18 @@ mod tests {
         app
             .add_systems(Startup, |mut commands: Commands| {
                 commands.spawn(Reactor::schedule(|task| async move {
-                    task.will(Update, once::run(|| {})).await;
+                    task.will(Update, delay::frames().with(1)).await;
                     task.will(Update, once::switch::off::<T>()).await;
                 }));
             })
-            .add_systems(Update, (|mut b: ResMut<Bool>| {
+            .add_systems(PostUpdate, (|mut b: ResMut<Bool>| {
                 **b = true;
             }).run_if(switch_just_turned_off::<T>));
 
         app.update();
         assert!(app.is_bool_false());
         app.update();
+       
         assert!(app.is_bool_true());
     }
 }

--- a/src/action/record/push.rs
+++ b/src/action/record/push.rs
@@ -1,9 +1,9 @@
-use bevy::prelude::World;
 use crate::action::record::push_track;
 use crate::prelude::record::EditRecordResult;
 use crate::prelude::record::Track;
 use crate::prelude::{ActionSeed, CancellationHandlers, Output, Runner};
 use crate::runner::RunnerIs;
+use bevy::prelude::World;
 
 /// Push the [`Track`](crate::prelude::Track) onto the [`Record`](crate::prelude::Record).
 ///
@@ -70,7 +70,7 @@ where
 mod tests {
     use crate::action::record::{Record, Track};
     use crate::action::{once, record};
-    use crate::prelude::{ActionSeed, Reactor, Omit, Rollback};
+    use crate::prelude::{ActionSeed, Omit, Reactor, Rollback};
     use crate::tests::test_app;
     use bevy::app::Startup;
     use bevy::prelude::{Commands, Update};
@@ -104,8 +104,6 @@ mod tests {
             }));
         });
         app.update();
-        app.assert_resource(1, |h: &Record<H1>| h.tracks.len());
-        app.update();
         app.assert_resource(2, |h: &Record<H1>| h.tracks.len());
     }
 
@@ -120,12 +118,6 @@ mod tests {
                 task.will(Update, push(H1)).await;
             }));
         });
-        app.update();
-        app.assert_resource(1, |h: &Record<H1>| h.tracks.len());
-        app.assert_resource(0, |h: &Record<H2>| h.tracks.len());
-        app.update();
-        app.assert_resource(1, |h: &Record<H1>| h.tracks.len());
-        app.assert_resource(1, |h: &Record<H2>| h.tracks.len());
         app.update();
         app.assert_resource(2, |h: &Record<H1>| h.tracks.len());
         app.assert_resource(1, |h: &Record<H2>| h.tracks.len());

--- a/src/action/record/redo.rs
+++ b/src/action/record/redo.rs
@@ -231,13 +231,7 @@ mod tests {
                     .unwrap();
             }));
         });
-        let mut er = exit_reader();
-        app.update();
-        app.assert_event_not_comes(&mut er);
-
-        app.update();
-        app.assert_resource_eq(Count(1));
-
+       
         app.update();
         app.assert_resource_eq(Count(0));
     }
@@ -278,10 +272,6 @@ mod tests {
             }));
         });
 
-        app.update();
-        app.assert_resource_eq(Mark(vec![]));
-        app.update();
-        app.assert_resource_eq(Mark(vec![]));
         app.update();
         app.assert_resource_eq(Mark(vec!["1", "2"]));
     }
@@ -324,10 +314,6 @@ mod tests {
         });
 
         app.update();
-        app.assert_resource_eq(Mark(vec![]));
-        app.update();
-        app.assert_resource_eq(Mark(vec![]));
-        app.update();
         app.assert_resource_eq(Mark(vec![1, 2, 3, 4]));
     }
 
@@ -369,10 +355,6 @@ mod tests {
         });
 
         app.update();
-        app.assert_resource_eq(Mark(vec![]));
-        app.update();
-        app.assert_resource_eq(Mark(vec![]));
-        app.update();
         app.assert_resource_eq(Mark(vec![1, 2]));
     }
 
@@ -403,10 +385,6 @@ mod tests {
             }));
         });
 
-        app.update();
-        app.assert_resource_eq(Count(0));
-        app.update();
-        app.assert_resource_eq(Count(0));
         app.update();
         app.assert_resource_eq(Count(3));
     }

--- a/src/action/sequence.rs
+++ b/src/action/sequence.rs
@@ -190,6 +190,7 @@ mod tests {
                     .then(once::res::insert().with(Mark2))
                     .then(once::run(|| { 1 + 1 })),
                 ).await;
+           
                 task.will(Update, once::res::insert().with(OutputUSize(output))).await;
             }));
         });

--- a/src/action/side_effect/bevy_task/spawn.rs
+++ b/src/action/side_effect/bevy_task/spawn.rs
@@ -111,7 +111,6 @@ mod tests {
 #[cfg(all(test, feature = "tokio"))]
 mod test_tokio {
     use bevy::app::{Startup, Update};
-    use bevy::core::TaskPoolPlugin;
     use bevy::prelude::Commands;
 
     use crate::action::side_effect;
@@ -121,7 +120,6 @@ mod test_tokio {
     #[test]
     fn not_failed_with_tokio_task() {
         let mut app = test_app();
-        app.add_plugins(TaskPoolPlugin::default());
         app.add_systems(Startup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
                 task.will(Update, {

--- a/src/action/side_effect/bevy_task/spawn_detached.rs
+++ b/src/action/side_effect/bevy_task/spawn_detached.rs
@@ -95,7 +95,6 @@ mod tests {
     use crate::prelude::{Pipe, Reactor};
     use crate::tests::test_app;
     use bevy::app::Startup;
-    use bevy::core::TaskPoolPlugin;
     use bevy::prelude::{Commands, Update};
     use bevy_test_helper::resource::count::Count;
     use bevy_test_helper::resource::DirectResourceControl;
@@ -104,7 +103,6 @@ mod tests {
     #[test]
     fn test_simple_spawn_detached() {
         let mut app = test_app();
-        app.add_plugins(TaskPoolPlugin::default());
         app.add_systems(Startup, |mut commands: Commands| {
             commands.spawn(Reactor::schedule(|task| async move {
                 task.will(Update, {

--- a/src/action/wait.rs
+++ b/src/action/wait.rs
@@ -132,25 +132,21 @@ mod tests {
     #[test]
     fn count_up() {
         let mut app = test_app();
-        app.world_mut()
-            .run_system_once(|mut commands: Commands| {
-                commands.spawn(Reactor::schedule(|task| async move {
-                    task.will(
-                        Update,
-                        until(|mut count: Local<u32>| {
-                            *count += 1;
-                            *count == 2
-                        }),
-                    )
-                        .await;
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                task.will(
+                    Update,
+                    until(|mut count: Local<u32>| {
+                        *count += 1;
+                        *count == 2
+                    }),
+                )
+                    .await;
 
-                    task.will(Update, once::non_send::insert().with(AppExit::Success)).await;
-                }));
-            })
-            .expect("Failed to run system");
+                task.will(Update, once::non_send::insert().with(AppExit::Success)).await;
+            }));
+        });
 
-        app.update();
-        assert!(app.world().get_non_send_resource::<AppExit>().is_none());
         app.update();
         assert!(app.world().get_non_send_resource::<AppExit>().is_none());
         app.update();
@@ -161,26 +157,22 @@ mod tests {
     fn count_up_until_with_input() {
         let mut app = test_app();
 
-        app.world_mut()
-            .run_system_once(|mut commands: Commands| {
-                commands.spawn(Reactor::schedule(|task| async move {
-                    task.will(
-                        Update,
-                        until(|input: In<u32>, mut count: Local<u32>| {
-                            *count += 1 + input.0;
-                            *count == 4
-                        })
-                            .with(1),
-                    )
-                        .await;
+        app.add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Reactor::schedule(|task| async move {
+                task.will(
+                    Update,
+                    until(|input: In<u32>, mut count: Local<u32>| {
+                        *count += 1 + input.0;
+                        *count == 4
+                    })
+                        .with(1),
+                )
+                    .await;
 
-                    task.will(Update, once::non_send::insert().with(AppExit::Success))
-                        .await;
-                }));
-            })
-            .expect("Failed to run system");
-        app.update();
-        assert!(app.world().get_non_send_resource::<AppExit>().is_none());
+                task.will(Update, once::non_send::insert().with(AppExit::Success))
+                    .await;
+            }));
+        });
         app.update();
         assert!(app.world().get_non_send_resource::<AppExit>().is_none());
         app.update();
@@ -204,9 +196,6 @@ mod tests {
         app.world_mut()
             .run_system_once(|mut w: EventWriter<AppExit>| w.send(AppExit::Success))
             .expect("Failed to run system");
-        app.update();
-        assert!(app.world().get_non_send_resource::<AppExit>().is_none());
-
         app.update();
         assert!(app.world().get_non_send_resource::<AppExit>().is_some());
     }
@@ -238,9 +227,6 @@ mod tests {
         app.world_mut()
             .run_system_once(|mut w: EventWriter<TestEvent2>| w.send(TestEvent2))
             .expect("Failed to run system");
-        app.update();
-        assert!(app.world().get_non_send_resource::<AppExit>().is_none());
-
         app.update();
         assert!(app.world().get_non_send_resource::<AppExit>().is_some());
     }

--- a/src/action/wait/all.rs
+++ b/src/action/wait/all.rs
@@ -303,9 +303,6 @@ mod tests {
             .run_system_once(|mut w: EventWriter<TestEvent2>| w.send(TestEvent2))
             .expect("Failed to run system");
         app.update();
-        assert!(app.world().get_non_send_resource::<AppExit>().is_none());
-
-        app.update();
         assert!(app.world().get_non_send_resource::<AppExit>().is_some());
     }
 
@@ -328,9 +325,6 @@ mod tests {
                     .await;
             }));
         });
-        app.update();
-        assert!(app.world().get_non_send_resource::<AppExit>().is_none());
-
         app.update();
         assert!(app.world().get_non_send_resource::<AppExit>().is_some());
     }

--- a/src/runner/app_schedule_labels.rs
+++ b/src/runner/app_schedule_labels.rs
@@ -1,0 +1,25 @@
+use bevy::ecs::schedule::InternedScheduleLabel;
+use bevy::prelude::{Deref, DerefMut, Resource, Schedules};
+use bevy::utils::HashSet;
+
+
+/// Manages the schedules registered in the main app.
+///
+/// This resource is used to confirm whether the schedule label of the system that the [`BoxedRunner`](crate::prelude::BoxedRunner)
+/// is running is already registered in the [`Schedules`].
+///
+/// The reason why it is not checked directly from [`Schedules`] is that when the scheduler is executed,
+/// the target scheduler is temporarily removed from [`Schedules`].
+#[derive(Resource, Debug, Deref, DerefMut)]
+pub(crate) struct AppScheduleLabels(pub HashSet<InternedScheduleLabel>);
+
+impl AppScheduleLabels {
+    #[inline]
+    pub fn current_running_on_target_schedule(
+        &self,
+        target: InternedScheduleLabel,
+        schedules: &Schedules,
+    ) -> bool {
+        self.0.contains(&target) && !schedules.contains(target)
+    }
+}

--- a/src/runner/reserve_register_runner.rs
+++ b/src/runner/reserve_register_runner.rs
@@ -1,0 +1,32 @@
+use bevy::app::{App, Last, Plugin};
+use bevy::ecs::schedule::InternedScheduleLabel;
+use bevy::ecs::system::BoxedSystem;
+use bevy::prelude::{on_event, Event, EventReader, IntoSystemConfigs, ResMut, Schedules};
+use itertools::Itertools;
+
+/// When the schedule to be registered is the same as the schedule currently being executed by the [`BoxedRunner`](crate::prelude::BoxedRunner),
+/// it cannot be registered normally, so it is temporarily stored and registered with [`Last`].
+pub struct ReserveRegisterRunnerPlugin;
+
+impl Plugin for ReserveRegisterRunnerPlugin {
+    fn build(&self, app: &mut App) {
+        app
+            .add_event::<ReservedRunner>()
+            .add_systems(Last, register_runner_system.run_if(on_event::<ReservedRunner>));
+    }
+}
+
+#[derive(Event, Debug)]
+pub(crate) struct ReservedRunner {
+    pub label: InternedScheduleLabel,
+    pub system: fn() -> BoxedSystem,
+}
+
+fn register_runner_system(
+    mut events: EventReader<ReservedRunner>,
+    mut schedules: ResMut<Schedules>,
+) {
+    for event in events.read().unique_by(|e| e.label) {
+        schedules.add_systems(event.label, (event.system)());
+    }
+}

--- a/src/task.rs
+++ b/src/task.rs
@@ -120,7 +120,6 @@ mod tests {
         app.update();
         assert!(app.world().get_non_send_resource::<AppExit>().is_none());
         app.update();
-        app.update();
         assert!(app.world().get_non_send_resource::<AppExit>().is_some());
     }
 }


### PR DESCRIPTION
Significantly improved performance.
 Previously, the reactor was executed every frame, but with this change, it is now called only when each of runner has completed its processing.

## Features

Added `StepAllReactors` and `StepReactor` trigger events to step the reactor manually.

 ## Breaking Changes

 When the runner’s processing is finished, the reactor now steps immediately.
 For example, when running the following test,  `Count` was 1, but from this version onward, it will be 3.
 
 ```rust
#[test]
fn count_is_3() {
    #[derive(Resource, Debug, Default, Eq, PartialEq)]
    struct Count(usize);

    let mut app = test_app();
    app.insert_resource(Count(0));

    app.add_systems(Startup, |mut commands: Commands| {
        commands.spawn(Reactor::schedule(|task| async move {
            task.will(Update, once::run(|mut count: ResMut<Count>| {
                count.0 += 1;
            })).await;
            task.will(Update, once::run(|mut count: ResMut<Count>| {
                count.0 += 1;
            })).await;
            task.will(Update, once::run(|mut count: ResMut<Count>| {
                count.0 += 1;
            })).await;
        }));
    });
    app.update();
    assert_eq!(app.world().resource::<Count>(), &Count(3));
}
 ```

From this version onward, if you invoke asynchronous processing other than an Action within the reactor’s async block as shown below, you will need to manually advance the reactor by triggering either StepAllReactors or StepReactor.
 ```rust
fn main() {
    App::new()
        .add_plugins((
            MinimalPlugins,
            LogPlugin::default(),
            FlurxPlugin,
        ))
        .add_systems(Startup, spawn_reactor)
        .add_systems(Update, step_reactors.run_if(switch_is_on::<TokioTaskRunning>))
        .run();
}

struct TokioTaskRunning;

fn spawn_reactor(mut commands: Commands) {
    commands.spawn(Reactor::schedule(|task| async move {
        task.will(Update, once::switch::on::<TokioTaskRunning>()).await;
        // By turning on feature flag `tokio`,
        // you can also directly write asynchronous functions depending on tokio's runtime in the reactor.
        // However, you need to manually advance the reactor.
        tokio::time::sleep(Duration::from_secs(1)).await;
        task.will(Update, once::switch::off::<TokioTaskRunning>()).await;
    }));
}

fn step_reactors(
    mut commands: Commands,
){
    commands.trigger(StepAllReactors);
}
 ```