### PR TITLE
update: side-effect feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ default = []
 audio = ["bevy/bevy_audio", "bevy/bevy_asset"]
 tokio = ["dep:tokio", "dep:async-compat"]
 record = []
-effect = []
+side-effect = []
 state = ["bevy/bevy_state"]
 
 [lints.clippy]

--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ All examples are [`here`](./examples).
 
 ## Feature flags
 
-| flag name | short description                                                                  | default |
-|-----------|------------------------------------------------------------------------------------|---------|
-| audio     | audio actions                                                                      | false   |
-| record    | undo/redo actions and events                                                       | false   | 
-| effect    | thread/async side effects                                                          | false   |
-| state     | state actions                                                                      | false   | 
-| tokio     | allows to use write asynchronous functions depend on tokio directly in the reactor | false   | 
+| flag name   | short description                                                                  | default |
+|-------------|------------------------------------------------------------------------------------|---------|
+| audio       | audio actions                                                                      | false   |
+| record      | undo/redo actions and events                                                       | false   | 
+| side-effect | thread/async side effects                                                          | false   |
+| state       | state actions                                                                      | false   | 
+| tokio       | allows to use write asynchronous functions depend on tokio directly in the reactor | false   | 
 
 ### audio
 
@@ -118,7 +118,7 @@ Provides `Record` to manage operation history.
 
 ![undo_redo](examples/undo_redo.gif)
 
-### effect
+### side-effect
 
 [doc.rs](https://docs.rs/bevy_flurx/latest/bevy_flurx/action/effect/index.html)
 

--- a/examples/bug_check/switch_just_change.rs
+++ b/examples/bug_check/switch_just_change.rs
@@ -30,7 +30,8 @@ fn setup(
                 .then(once::switch::on::<S>())
                 .then(delay::frames().with(1))
                 .then(wait::input::just_pressed().with(KeyCode::KeyT))
-                .then(once::switch::off::<S>()),
+                .then(once::switch::off::<S>())
+                .then(delay::frames().with(1)),
             ).await;
         }
     }));

--- a/examples/side_effect.rs
+++ b/examples/side_effect.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Notes
 //! 
-//! You need to enable the `effect` and `tokio` feature flags to use this feature.
+//! You need to enable the `side-effect` and `tokio` feature flags to use this feature.
 
 use bevy::log::LogPlugin;
 use bevy::prelude::*;

--- a/src/action.rs
+++ b/src/action.rs
@@ -42,23 +42,9 @@ pub mod omit;
 mod _tuple;
 mod map;
 mod remake;
-#[cfg(feature = "effect")]
-#[cfg_attr(docsrs, doc(cfg(feature = "effect")))]
+#[cfg(feature = "side-effect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "side-effect")))]
 pub mod side_effect;
-
-#[allow(deprecated)]
-#[cfg(feature = "effect")]
-#[deprecated(
-    since = "0.9.1",
-    note = r#"
-    `effect` has been renamed to `side_effect` and this module will be removed in the `0.10`.
-    The name of the feature flag will also be `side_effect`.
-    "#
-)]
-/// Convert the operations with side effects such as asynchronous runtime or thread into the referential-transparent actions.
-pub mod effect{
-    pub use super::side_effect::*;
-}
 
 #[cfg(feature = "record")]
 #[cfg_attr(docsrs, doc(cfg(feature = "record")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub mod prelude {
         extension::{RecordExtension, RequestRedo, RequestUndo},
         EditRecordResult, Record, Redo, RedoAction, Rollback, Track, Undo, UndoRedoInProgress,
     };
-    #[cfg(feature = "effect")]
+    #[cfg(feature = "side-effect")]
     pub use crate::action::side_effect::AsyncFunctor;
     pub use crate::{
         action::inspect::{inspect, Inspect},


### PR DESCRIPTION
## Breaking Changes

- rename feature `effect` to `side-effect`
- delete `effect` module path; please use `side_effect` instead.