### PR TITLE
update: It is now possible to request undo/redo from trigger.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Added `wait::event::comes_and` and `wait::event::read_and` actions that wait for an event with a predicate.
 - It is now possible to request undo/redo from trigger.
 
+## Breaking Changes
+
+- Renamed `App::add_record_events` to `App::add_record`.
+
 ## v0.11.0-rc.2
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.11.0-rc.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Added `wait::event::comes_and` and `wait::event::read_and` actions that wait for an event with a predicate.
+- It is now possible to request undo/redo from trigger.
 
 ## v0.11.0-rc.2
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.11.0-rc.2)

--- a/examples/undo_redo.rs
+++ b/examples/undo_redo.rs
@@ -19,8 +19,8 @@ fn main() {
         .init_resource::<KeyCodes>()
         .add_systems(Update, (
             log_keycodes.run_if(resource_exists_and_changed::<KeyCodes>),
-            do_undo.run_if(input_just_pressed(KeyCode::KeyZ)),
-            do_redo.run_if(input_just_pressed(KeyCode::KeyX)),
+            request_undo.run_if(input_just_pressed(KeyCode::KeyZ)),
+            request_redo.run_if(input_just_pressed(KeyCode::KeyX)),
             push_num_keycodes,
         ))
         .run();
@@ -40,14 +40,14 @@ fn log_keycodes(
     info!("{:?}", key_codes);
 }
 
-fn do_undo(mut ew: EventWriter<RequestUndo<KeyCodeAct>>) {
+fn request_undo(mut commands: Commands) {
     info!("Undo");
-    ew.write(RequestUndo::Once);
+    commands.trigger(RequestUndo::<KeyCodeAct>::Once);
 }
 
-fn do_redo(mut ew: EventWriter<RequestRedo<KeyCodeAct>>) {
+fn request_redo(mut commands: Commands) {
     info!("Redo");
-    ew.write(RequestRedo::Once);
+    commands.trigger(RequestRedo::<KeyCodeAct>::Once);
 }
 
 fn push_num_keycodes(

--- a/examples/undo_redo.rs
+++ b/examples/undo_redo.rs
@@ -14,8 +14,7 @@ fn main() {
             DefaultPlugins,
             FlurxPlugin,
         ))
-        .add_record_events::<KeyCodeAct>()
-        .init_resource::<Record<KeyCodeAct>>()
+        .add_record::<KeyCodeAct>()
         .init_resource::<KeyCodes>()
         .add_systems(Update, (
             log_keycodes.run_if(resource_exists_and_changed::<KeyCodes>),

--- a/src/action/record/extension.rs
+++ b/src/action/record/extension.rs
@@ -2,7 +2,7 @@
 //! from outside [`Reactor`].
 
 use crate::action::record;
-use crate::prelude::{ActionSeed, Omit, Reactor, Then};
+use crate::prelude::{ActionSeed, Omit, Reactor, Record, Then};
 use bevy::app::{App, PostUpdate, Update};
 use bevy::prelude::{on_event, Commands, Event, EventReader, IntoScheduleConfigs, Trigger};
 
@@ -74,17 +74,18 @@ where
 /// from outside [`Reactor`].
 pub trait RecordExtension {
     /// Set up [`RequestUndo`] and [`RequestRedo`] and their associated systems.
-    fn add_record_events<Act>(&mut self) -> &mut Self
+    fn add_record<Act>(&mut self) -> &mut Self
     where
         Act: Clone + PartialEq + Send + Sync + 'static;
 }
 
 impl RecordExtension for App {
-    fn add_record_events<Act>(&mut self) -> &mut Self
+    fn add_record<Act>(&mut self) -> &mut Self
     where
         Act: Clone + PartialEq + Send + Sync + 'static,
     {
         self
+            .init_resource::<Record<Act>>()
             .add_event::<RequestUndo<Act>>()
             .add_event::<RequestRedo<Act>>()
             .add_systems(PostUpdate, (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,8 +115,8 @@ mod tests {
         #[cfg(feature = "record")]
         {
             use crate::prelude::{Record, RecordExtension};
-            app.add_record_events::<NumAct>();
-            app.add_record_events::<TestAct>();
+            app.add_record::<NumAct>();
+            app.add_record::<TestAct>();
             app.init_resource::<Record<TestAct>>();
         }
         


### PR DESCRIPTION
Please see [examples/undo_redo.rs](https://github.com/not-elm/bevy_flurx/blob/main/examples/undo_redo.rs) for usage.

## Breaking Change

- Renamed `App::add_record_event` to `App::add_record`.

## Features

- It is now possible to request undo/redo from trigger.
- Since `App::init_resource::<Record<T>>` is now called within `App::add_record`, it is no longer necessary to explicitly initialize Record.