### PR TITLE
Remove `Sync` bound from `AsyncFunctor` in `tokio::spawn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,59 @@
+## v0.14.1(Unreleased)
+
+[Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.14.1)
+
+### Improvements
+
+- Removed `Sync` bound from `AsyncFunctor` in `side_effect::tokio::spawn`, allowing `Send`-only closures
+
 ## v0.14.0
+
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.14.0)
 
 ### Improvements
+
 - Migrated to Bevy 0.18
 
 ## v0.13.0
+
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.13.0)
 
 ### Features
+
 - Support for Bevy 0.17.0
 - Added `once::message` module with `write()`, `write_default()`, and `app_exit_success()` actions
 - Added `wait::message` module with `comes()`, `comes_and()`, `read()`, and `read_and()` actions
 
 ### Deprecations
+
 - Deprecated `once::event` module in favor of `once::message` (Event trait replaced with Message in Bevy 0.17)
 - Deprecated `wait::event` module in favor of `wait::message` (Event trait replaced with Message in Bevy 0.17)
 
 ### Improvements
+
 - Updated all examples, documentation, and tests to use the new `message` API
 - Deprecated functions now delegate to their `message` equivalents for consistency
 
 ## v0.12.0
+
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.12.0)
 
 ### Features
+
 - Support no_std
 - Added `serialize` feature flag to derive `Serialize` and `Deserialize` for some structs.
+
 ### Bug Fixes
+
 - Fixed a bug where `side_effect::tokio::spawn` was blocking execution.
 - Fixed a potential bug in the internal `RunnersRegistry` usage.
+
 ### Improvements
+
 - Remove `serialize` and `std` feature flags from `bevy` dependency.
 
 ## v0.11.1
+
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.11.1)
 
 ### Others
@@ -41,19 +62,21 @@
 - Use rustfmt to format the code.
 
 ## v0.11.0
+
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.11.0)
 
 ### Features
 
 - Support for Bevy's 0.16.0
 
-
 ## v0.11.0-rc.5
+
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.11.0-rc.5)
 
 Support for Bevy's 0.16-rc.5
 
 ## v0.11.0-rc.3
+
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.11.0-rc.3)
 
 ## Features
@@ -67,13 +90,15 @@ Support for Bevy's 0.16-rc.5
 - Renamed `App::add_record_events` to `App::add_record`.
 
 ## v0.11.0-rc.2
+
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.11.0-rc.2)
 
 ## Bug Fix
 
 - Fixed crash app when Reactor spawns inside another reactor
 
-## v0.11.0-rc.1 
+## v0.11.0-rc.1
+
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.11.0-rc.1)
 
 Support for bevy 0.16.0-rc.1
@@ -115,7 +140,7 @@ Support for bevy 0.16.0-rc.1
 [Release note](https://github.com/not-elm/bevy_flurx/releases/tag/v0.9.0)
 
 - Added the `inspect` module, providing utilities for auxiliary side-effect handling (e.g., logging or debugging) with the `inspect` function and `Inspect` trait.
-- Added `Action::split` method to split an action into an input value and a seed. 
+- Added `Action::split` method to split an action into an input value and a seed.
 - Changed access modifier for `ActionSeed::create_runner` and `Action::create_runner` to pub.
 
 ## v0.8.3
@@ -173,7 +198,7 @@ This version has reduced the binary size.
 
 ## v0.5.0
 
-Fixed a bug where the execution run condition switch_just_* was not working correctly
+Fixed a bug where the execution run condition switch*just*\* was not working correctly
 
 - [v0.5.0](https://github.com/not-elm/bevy_flurx/pull/44)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+bevy_flurx is a Bevy plugin that provides coroutine-like sequential control flow within Bevy's synchronous ECS. It enables async-like syntax (using `.await`) for describing delays, state waits, character movement, and user input handling — without a real async runtime. Supports `no_std`.
+
+**Current version:** 0.14.0 (targets Bevy 0.18)
+
+## Build & Test Commands
+
+```bash
+# Run tests (standard CI command — includes all commonly-used features)
+cargo test -F state,audio,tokio,record,side-effect
+
+# Run tests with all features
+cargo test --all-features
+
+# Run doc tests only (also compiles README examples)
+cargo test --doc --all-features
+
+# Lint
+cargo clippy --workspace --all-targets --all-features -- -Dwarnings
+
+# Format check
+cargo fmt --all -- --check
+
+# Run a single test
+cargo test <test_name> -F state,audio,tokio,record,side-effect
+
+# Run benchmarks
+cargo bench --bench single
+cargo bench --bench repeat
+
+# Run examples (some require feature flags)
+cargo run --example simple
+cargo run --example side_effect -F tokio,side-effect
+cargo run --example undo_redo -F record
+```
+
+## Feature Flags
+
+| Flag | Purpose |
+|------|---------|
+| `audio` | Audio actions (requires bevy_audio, bevy_asset) |
+| `tokio` | Tokio runtime integration |
+| `record` | Undo/redo system |
+| `side-effect` | Thread/async side effects |
+| `state` | Bevy state actions |
+| `std` | Standard library features |
+| `serialize` | Serde serialization support |
+
+No features are enabled by default. Tests should be run with `-F state,audio,tokio,record,side-effect` to match CI.
+
+## Architecture
+
+### Core Execution Flow
+
+1. **Reactor** (`src/reactor.rs`) — A Bevy component spawned with `Reactor::schedule(|task| async move { ... })`. Uses an entity on-add hook to initialize a `NativeReactor` that manages the async block.
+2. **ReactorTask** (`src/task.rs`) — Passed into the Reactor's async closure. `task.will(schedule_label, action).await` submits an action and suspends until it completes.
+3. **Runner** (`src/runner.rs`) — Trait for executing actions. Each `task.will()` call registers a `BoxedRunner` in a per-entity `TypedRegistry`. Runners are polled each frame until they return `RunnerIs::Completed` or `RunnerIs::Canceled`.
+4. **CoreScheduler** (`src/core/scheduler.rs`) — Manages the async future for a single reactor, polling it frame-by-frame.
+5. **Output<T>** (`src/runner/output.rs`) — `Arc<RwLock<Option<T>>>` channel for passing action results back to the awaiting task.
+
+When all actions in a Reactor complete, the reactor entity is automatically despawned.
+
+### Action System (`src/action/`)
+
+- **Action<I, O>** — Bundles an input value with an `ActionSeed`
+- **ActionSeed<I, O>** — Lazy action descriptor that creates a runner when executed
+- Composition traits: `Then` (sequential), `Pipe` (output→input chaining), `Through` (pass-through), `Map` (transform output), `Inspect` (observe), `Omit` (erase types)
+
+Action modules:
+- `once/` — Execute a system exactly once (resources, messages, events, audio, state, switch)
+- `wait/` — Poll each frame until a condition is met (input, messages, events, audio, state, switch, combinators: `all`, `any`, `both`, `either`)
+- `delay/` — Time-based or frame-based delays
+- `pipe/`, `sequence/`, `through/`, `switch/` — Composition and control flow
+- `record/` — Undo/redo (feature-gated: `record`)
+- `side_effect/` — Thread/async/Bevy task execution (feature-gated: `side-effect`)
+
+### Macros
+
+- `sequence![a, b, c]` — Sequential action execution
+- `actions![a, b]` — Create an array of type-erased actions
+
+### Key Patterns
+
+- **Selector** (`src/selector.rs`, `src/core/selector.rs`) — Interface for selecting data from the World to feed into actions
+- **WorldPtr** (`src/world_ptr.rs`) — Unsafe wrapper for accessing `&mut World` across the async boundary
+- **Runner registration** — Dynamic system insertion into Bevy schedules via `AppScheduleLabels`
+- **Bevy 0.18 Message API** — The codebase uses `Message`/`MessageReader`/`MessageWriter` (not the older `Event` trait)
+
+## Lint Configuration
+
+Configured in `Cargo.toml`:
+- `clippy::type_complexity` = allow
+- `clippy::doc_markdown` = warn
+- `clippy::undocumented_unsafe_blocks` = warn
+- `rust::missing_docs` = warn
+
+## Testing Patterns
+
+Tests use `bevy_test_helper` crate (from a git dependency). The common test setup is:
+```rust
+let mut app = test_app(); // defined in src/lib.rs — adds MinimalPlugins, InputPlugin, StatesPlugin, FlurxPlugin
+app.add_systems(Startup, |mut commands: Commands| {
+    commands.spawn(Reactor::schedule(|task| async move {
+        // test actions here
+    }));
+});
+app.update(); // advance frames
+```
+
+Helper functions: `increment_count()`, `decrement_count()`, `exit_reader()`, `came_event::<E>()`.
+
+## Versioning
+
+Pre-v1.0 semver: breaking changes increment MINOR version. See `VERSION_RULE.md`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_flurx"
-version = "0.14.0"
+version = "0.14.1-dev"
 edition = "2021"
 authors = ["notelm <elmprograminfo@gmail.com>"]
 categories = ["asynchronous", "game-development", "no-std"]
@@ -42,8 +42,12 @@ futures-lite = "2"
 pollster = "0.4"
 pin-project = "1"
 itertools = "0.14"
-serde = { version = "1", features = ["derive"]}
-tokio = { version = "1", optional = true, features = ["sync", "time", "rt-multi-thread"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", optional = true, features = [
+  "sync",
+  "time",
+  "rt-multi-thread",
+] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-compat = { version = "0.2", optional = true }

--- a/src/action/side_effect/tokio.rs
+++ b/src/action/side_effect/tokio.rs
@@ -204,9 +204,8 @@ mod tests {
         use core::cell::Cell;
         let non_sync = Cell::new(42u32);
         // Cell<u32> is Send but !Sync — this must compile
-        let _seed: ActionSeed<(), u32> = side_effect::tokio::spawn(move |_| async move {
-            non_sync.get()
-        });
+        let _seed: ActionSeed<(), u32> =
+            side_effect::tokio::spawn(move |_| async move { non_sync.get() });
     }
 
     #[test]

--- a/src/action/side_effect/tokio.rs
+++ b/src/action/side_effect/tokio.rs
@@ -8,6 +8,7 @@ use crate::action::side_effect::AsyncFunctor;
 use crate::prelude::{ActionSeed, CancellationHandlers, RunnerIs};
 use crate::runner::{Output, Runner};
 use alloc::sync::Arc;
+use bevy::platform::sync::Mutex;
 use bevy::prelude::World;
 use core::marker::PhantomData;
 use tokio::runtime::Runtime;
@@ -41,15 +42,22 @@ where
     I: Send + Sync + 'static,
     M: Send + Sync + 'static,
     Out: Send + Sync + 'static,
-    Functor: AsyncFunctor<I, Out, M> + Send + Sync + 'static,
+    Functor: AsyncFunctor<I, Out, M> + Send + 'static,
 {
-    ActionSeed::new(|input: I, output: Output<Out>| TokioRunner {
-        arc_output: Arc::new(tokio::sync::Mutex::new(None)),
-        args: Some((input, f)),
-        output,
-        rt: Runtime::new().unwrap(),
-        handle: None,
-        _m: PhantomData,
+    let f = Mutex::new(Some(f));
+    ActionSeed::new(move |input: I, output: Output<Out>| {
+        let f = f
+            .into_inner()
+            .expect("mutex was never locked")
+            .expect("closure is FnOnce; value is always Some");
+        TokioRunner {
+            arc_output: Arc::new(tokio::sync::Mutex::new(None)),
+            args: Some((input, f)),
+            output,
+            rt: Runtime::new().unwrap(),
+            handle: None,
+            _m: PhantomData,
+        }
     })
 }
 
@@ -188,6 +196,17 @@ mod tests {
         thread::sleep(Duration::from_millis(200));
         app.assert_message_not_comes(&mut er);
         assert!(!TASK_FINISHED.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn accepts_non_sync_functor() {
+        use crate::prelude::ActionSeed;
+        use core::cell::Cell;
+        let non_sync = Cell::new(42u32);
+        // Cell<u32> is Send but !Sync — this must compile
+        let _seed: ActionSeed<(), u32> = side_effect::tokio::spawn(move |_| async move {
+            non_sync.get()
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Relaxes the `Sync` requirement on closures passed to `side_effect::tokio::spawn`, wrapping the functor in a `Mutex` to accept `Send`-only closures
- Adds a compile-time test verifying `Send`-only closures work
- Includes a changelog entry for v0.14.1

## Test plan
- [x] Compile-time test for `Send`-only closures added
- [x] `cargo test -F state,audio,tokio,record,side-effect` passes
- [x] `cargo clippy --workspace --all-targets --all-features -- -Dwarnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)